### PR TITLE
Mark collapsible as maintained

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1463,8 +1463,7 @@
     "githubUrl": "https://github.com/oblador/react-native-collapsible",
     "ios": true,
     "android": true,
-    "expo": true,
-    "unmaintained": true
+    "expo": true
   },
   {
     "githubUrl": "https://github.com/jeanregisser/react-native-popover",


### PR DESCRIPTION
The project has a new maintainer and would say it's fairly active for it's size at the moment: https://github.com/oblador/react-native-collapsible/pulse/monthly