### PR TITLE
Remove duplicate of react-native-pdf-view

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1178,11 +1178,6 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/cnjon/react-native-pdf-view",
-    "ios": true,
-    "android": true
-  },
-  {
     "githubUrl": "https://github.com/kayla-tech/react-native-card-io",
     "ios": true,
     "android": true


### PR DESCRIPTION
Removing duplicate entry of `react-native-pdf-view`

Appears on line [291](https://github.com/react-community/native-directory/blob/95afe29a916d21d3707efc3975cfabb0776478d5/react-native-libraries.json#L291) and [1181](https://github.com/react-community/native-directory/blob/95afe29a916d21d3707efc3975cfabb0776478d5/react-native-libraries.json#L1181) of the `react-native-libraries.json` file at the time of this commit. 

I removed the latest entry.