### PR TITLE
Implement a new scoring system

### DIFF
--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -5,6 +5,7 @@ import jsonfile from 'jsonfile';
 import _ from 'lodash';
 import fetchGithubData from './fetch-github-data';
 import calculateScore from './calculate-score';
+import fetchLicense from "./fetch-license";
 import fetchReadmeImages from './fetch-readme-images';
 import fetchNpmData from './fetch-npm-data';
 
@@ -35,6 +36,10 @@ const buildAndScoreData = async () => {
   console.log('** Loading data from Github');
   await sleep(1000);
   let data = await loadRepositoryDataAsync();
+
+  console.log('** Fetching license type');
+  await sleep(1000);
+  data = await Promise.all(data.map(d => fetchLicense(d, d.github.fullName)));
 
   console.log('\n** Scraping images from README');
   await sleep(1000);

--- a/scripts/calculate-score.js
+++ b/scripts/calculate-score.js
@@ -1,63 +1,94 @@
+// This is an array of modifier objects. Each modifier has a name, value, and condition.
+// The condiction is passed the data and if it returns true, the value is added to the
+// libraries score.
+// 
+// The idea is to add to the score for good behaviour and subtract from the score for
+// bad behaviour. It is completely reasonable for no modifiers to match a given library
+// and it should get a score close to the middle. To help with this, the positive and
+// negative modifier scores should be roughly the same magnitude.
+const modifiers = [
+  {
+    name: "Very popular",
+    value: 40,
+    condition: data => popularityScore(data) > 10000
+  },
+  {
+    name: "Popular",
+    value: 10,
+    condition: data => popularityScore(data) > 2500
+  },
+  {
+    name: "Recommended",
+    value: 20,
+    condition: data => data.goldstar
+  },
+  {
+    name: "Lots of open issues",
+    value: -20,
+    condition: data => data.github.stats.issues >= 75
+  },
+  {
+    name: "No license",
+    value: -20,
+    condition: data => data.license === null
+  },
+  {
+    name: "GPL license",
+    value: -20,
+    condition: data => data.license && data.license.key && data.license.key.startsWith("gpl")
+  },
+  {
+    name: "Recently updated",
+    value: 10,
+    condition: data => getUpdatedDaysAgo(data) <= 30 // Roughly 1 month
+  },
+  {
+    name: "Not updated recently",
+    value: -20,
+    condition: data => getUpdatedDaysAgo(data) >= 180 // Roughly 6 months
+  }
+];
+
+// Calculate the minimum and maximum possible scores based on the modifiers
+const minScore = modifiers.reduce((currentMin, modifier) => {
+  return modifier.value < 0 ? currentMin + modifier.value : currentMin;
+}, 0)
+const maxScore = modifiers.reduce((currentMax, modifier) => {
+  return modifier.value > 0 ? currentMax + modifier.value : currentMax;
+}, 0);
+
 const calculateScore = data => {
-  let { github, npm } = data;
-  let score = 0;
+  // Filter the modifiers to the ones which condictions pass with the data
+  const matchingModifiers = modifiers.filter(modifier => modifier.condition(data));
 
-  const daysAgo = getDaysAgo(github.stats.updatedAt);
+  // Reduce the matching modifiers to find the raw score for the data
+  const rawScore = matchingModifiers.reduce((currentScore, modifier) => {
+    return currentScore + modifier.value
+  }, 0);
 
-  if (daysAgo <= 30) {
-    score += 15;
-  } else if (daysAgo <= 60) {
-    score += 10;
-  } else if (daysAgo <= 90) {
-    score += 5;
+  // Scale the raw score as a percentage between the minimum and maximum possible score
+  // based on the available modifiers
+  const score = Math.round(((rawScore - minScore) / (maxScore - minScore)) * 100);
+
+  // Map the modifiers to the name so we can include that in the data
+  const matchingModifierNames = matchingModifiers.map(modifier => modifier.name);
+  
+  return {
+    ...data,
+    score,
+    matchingScoreModifiers: matchingModifierNames
   }
-
-  if (github.stats.hasIssues) {
-    score += 5;
-  }
-
-  if (github.stats.hasWiki) {
-    score += 5;
-  }
-
-  if (github.stats.hasPages) {
-    score += 5;
-  }
-
-  if (npm.downloads >= 2500) {
-    score += 25;
-  } else if (npm.downloads >= 500) {
-    score += 20;
-  } else if (npm.downloads >= 100) {
-    score += 15;
-  }
-
-  if (github.stats.hasTopics) {
-    score += 10;
-  }
-
-  if (github.stats.watchers > 10) {
-    score += 5;
-  }
-
-  if (github.stats.forks > 5) {
-    score += 10;
-  }
-
-  if (github.stats.stars >= 2500) {
-    score += 20;
-  } else if (github.stats.stars >= 500) {
-    score += 15;
-  } else if (github.stats.stars >= 100) {
-    score += 10;
-  }
-
-  data.score = score;
-  return data;
 };
 
-const getDaysAgo = date => {
-  const updateDate = new Date(date).getTime();
+const popularityScore = data => {
+  let { subscribers, forks, stars } = data.github.stats;
+  let { downloads } = data.npm;
+  return (subscribers * 20) + (forks * 10) + stars + (downloads / 100);
+};
+
+const getUpdatedDaysAgo = data => {
+  const { updatedAt } = data.github.stats;
+  const updateDate = new Date(updatedAt).getTime();
   const currentDate = new Date().getTime();
 
   return (currentDate - updateDate) / 1000 / 60 / 60 / 24;

--- a/scripts/fetch-github-data.js
+++ b/scripts/fetch-github-data.js
@@ -40,10 +40,11 @@ const createRepoDataWithResponse = json => {
       pushedAt: json.pushed_at,
       forks: json.forks,
       issues: json.open_issues,
-      watchers: json.watchers_count,
+      subscribers: json.subscribers_count,
       stars: json.stargazers_count,
     },
     name: json.name,
+    fullName: json.full_name,
     description: json.description,
     topics: json.topics,
   };

--- a/scripts/fetch-license.js
+++ b/scripts/fetch-license.js
@@ -1,0 +1,22 @@
+import "isomorphic-fetch";
+import { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET } from "../secrets.json";
+
+const API = "https://api.github.com";
+
+const githubLicenceInfo = async repoName => {
+  const requestUrl = `${API}/repos/${repoName}/license?client_id=${GITHUB_CLIENT_ID}&client_secret=${GITHUB_CLIENT_SECRET}`;
+  let response = await fetch(requestUrl);
+  let json = await response.json();
+  return json.license || null;
+};
+
+const fetchLicense = async (data, repoName) => {
+  let license = await githubLicenceInfo(repoName);
+
+  return {
+    ...data,
+    license
+  };
+};
+
+export default fetchLicense;


### PR DESCRIPTION
I have implemented a new scoring system based on the ideas from the [Cocoapods Quality Metrics](https://guides.cocoapods.org/making/quality-indexes). The new system takes into account:

* Popularity using the subscribers, forks, stars, and npm downloads with items at the start of the list weighted for greater importance as they indicate a more active contribution to the project.
* If the library is marked as recommended (called `goldstar` internally).
* If there are lots of open issues (currently set to 75).
* If there is no licence or a licence which is deemed incompatible with the Apple App Store.
* If the library has been recently updated (last 30 days) or not been updated in a while (over 6 months).

To help compare the previous and new scores, I have produced some statistics using [this script](https://gist.github.com/matt-oakes/55e8cb02d40555f083cb1a468923a96a):

```
Old mean:  73.82
New mean:  55.15
Mean difference:  -18.67

Number of libraries:  258
Match modifier counts:  {
  "Popular": 51,
  "Recently updated": 252,
  "No license": 60,
  "Lots of open issues": 14,
  "Very popular": 10,
  "Recommended": 10,
  "GPL license": 1
}
```

The average score is now lower, but I think this is correct. 50 should be the mark of an average quality library with lower and higher scores being indicative of the quality.

I have also put the data into a Google Sheet to allow you to check over the data more thoroughly:

https://docs.google.com/spreadsheets/d/1GIaIS_JIiz1ile5RknQPF6rjWFbfX8yRaYWB-vH-NQA/edit#gid=904868035

Looking through the scores, most seem to have been reduced because Github cannot determine which licence the library is under. I think this is a valid reason to reduce the score as this would be a barrier to using the library for most people.

All of these values and modifiers and be easily tweaked to fine tune the score.

Let me know what you think!

*Closes #33.*