### PR TITLE
Added web compatible libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -128,6 +128,7 @@
     "githubUrl": "https://github.com/wix/react-native-calendars",
     "ios": true,
     "android": true,
+    "web": true,
     "expo": true,
     "goldstar": true,
     "examples": [
@@ -138,6 +139,7 @@
     "githubUrl": "https://github.com/oblador/react-native-vector-icons",
     "ios": true,
     "android": true,
+    "web": true,
     "expo": true,
     "goldstar": true
   },
@@ -209,6 +211,7 @@
     "githubUrl": "https://github.com/react-native-community/react-native-tab-view",
     "ios": true,
     "android": true,
+    "web": true,
     "expo": true,
     "goldstar": true,
     "examples": [
@@ -570,6 +573,7 @@
     "githubUrl": "https://github.com/FormidableLabs/victory-native",
     "ios": true,
     "android": true,
+    "web": true,
     "expo": true
   },
   {

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1649,5 +1649,12 @@
     "android": true,
     "web": false,
     "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/peggyrayzis/react-native-create-bridge",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
   }
 ]


### PR DESCRIPTION
To help push adoption of universal components forward, I really want `native.directory` to be a one stop shop for people looking for RN libs that work on web.

I went ahead and added libs that I know for sure work on web (we used them in prod at MLS). Over the next few days, I'm going to be adding more once I write a script to determine a lib's web compatibility %.

I also added `react-native-create-bridge` to the directory. 😀 