### PR TITLE
Add react-native-actionsheet, native-navigation and react-native-navigation

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -82,6 +82,20 @@
     ]
   },
   {
+    "githubUrl": "https://github.com/airbnb/native-navigation",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
+    "githubUrl": "https://github.com/wix/react-native-navigation",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
     "githubUrl": "https://github.com/gre/gl-react",
     "ios": true,
     "android": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1684,5 +1684,12 @@
     "android": true,
     "web": false,
     "expo": false
+  },
+  {
+    "githubUrl": "https://github.com/beefe/react-native-actionsheet",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
   }
 ]


### PR DESCRIPTION
Hi, [ActionSheet](https://github.com/beefe/react-native-actionsheet), [react-native-navigation](https://github.com/wix/react-native-navigation) and [native-navigation](https://github.com/airbnb/native-navigation) library for iOS and Android. 