### PR TITLE
Proposed Addition: React Native Schemes Manager

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1886,5 +1886,12 @@
     "ios": true,
     "android": true,
     "expo": true
-  }
+  },
+  {
+    "githubUrl": "https://github.com/thinkmill/react-native-schemes-manager",
+    "ios": true,
+    "android": false,
+    "web": false,
+    "expo": false
+  },
 ]


### PR DESCRIPTION
React Native Schemes Manager helps you have different environment variables for your React Native App via XCode Schemes. Why is this useful? You can have a Staging build and a Production build of the application with different icons, pointing to different servers. They can have different app IDs so users can run both on their phone at the same time.

React native doesn't support this behaviour out of the box because as soon as it encounters a scheme called anything other than `Debug` it disables the debugging menu and does a release build. This package edits the `.xcodeproj` files inside `node_modules` so that schemes will work how they're supposed to, and you can continue to debug your JS on all environments.