### PR TITLE
Added react-native-material-showcase-ios & react-native-taptargetview libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,5 +1,19 @@
 [
   {
+    "githubUrl": "https://github.com/prscX/react-native-material-showcase-ios",
+    "ios": true,
+    "android": false,
+    "web": false,
+    "expo": false
+  },
+  {
+    "githubUrl": "https://github.com/prscX/react-native-taptargetview",
+    "ios": false,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
     "githubUrl": "https://github.com/hectahertz/react-native-typography",
     "ios": true,
     "android": true,


### PR DESCRIPTION
Hi @jimmylee 

This is with reference to issue: [87](https://github.com/react-community/native-directory/issues/87) & [84](https://github.com/react-community/native-directory/issues/84). As guided I have added both libraries in react-native-libraries.json file

Can you please merge this PR. Please let me know in case any changes are required

Thanks
Pranav