### PR TITLE
Add web support to react-native-typography

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3,7 +3,7 @@
     "githubUrl": "https://github.com/hectahertz/react-native-typography",
     "ios": true,
     "android": true,
-    "web": false,
+    "web": true,
     "expo": true
   },
   {


### PR DESCRIPTION
We just added support for the web platform in version [1.2.1](https://github.com/hectahertz/react-native-typography/releases/tag/v1.2.1).

Thanks!