### PR TITLE
Add React Native Bridge for Native Spruce Library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,5 +1,12 @@
 [
   {
+    "githubUrl": "https://github.com/prscX/react-native-spruce",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
     "githubUrl": "https://github.com/prscX/react-native-material-showcase-ios",
     "ios": true,
     "android": false,


### PR DESCRIPTION
Hi,

I have created a React Native bridge plugin for [willowtreeapps/spruce-android](https://github.com/willowtreeapps/spruce-android). It help developers to easily animate views at the appropriate time. Can you please add below npm node to your React Native packages list:

Name: react-native-spruce
Repository: [react-native-spruce](https://github.com/prscX/react-native-spruce) 

Please let me know in case any discuss is required for the same

Thanks
Pranav