### PR TITLE
Add React Native Bridge for Native (Shine Button, Iconic Button, Download Button) Libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,5 +1,26 @@
 [
   {
+    "githubUrl": "https://github.com/prscX/react-native-shine-button",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
+    "githubUrl": "https://github.com/prscX/react-native-iconic",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
+    "githubUrl": "https://github.com/prscX/react-native-download-button",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
     "githubUrl": "https://github.com/prscX/react-native-spruce",
     "ios": true,
     "android": true,


### PR DESCRIPTION
Hi,

I have created below React Native bridge plugins:

- [react-native-shine-button](https://github.com/prscX/react-native-shine-button)
- [react-native-iconic](https://github.com/prscX/react-native-iconic)
- [react-native-download-button](https://github.com/prscX/react-native-download-button)

Can you please add above npm node to your React Native packages list. Please let me know in case any discuss is required for the same

Thanks
Pranav