### PR TITLE
Added React Native Bridge for Native (Bottom Sheet, Popover) Libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,5 +1,19 @@
 [
   {
+    "githubUrl": "https://github.com/prscX/react-native-bottom-action-sheet",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
+    "githubUrl": "https://github.com/prscX/react-native-popover-menu",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
     "githubUrl": "https://github.com/prscX/react-native-shine-button",
     "ios": true,
     "android": true,


### PR DESCRIPTION
Hi,

I have created below React Native bridge plugins:

- [react-native-bottom-action-sheet](https://github.com/prscX/react-native-bottom-action-sheet)
- [react-native-popover-menu](https://github.com/prscX/react-native-popover-menu)

I have added the above libraries in `react-native-libraries.json` file, can you please merge this PR. Please let me know in case any discuss is required for the same

Thanks
Pranav