### PR TITLE
Updated tamagui expoGo and added @tamagui/* packages

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12672,7 +12672,6 @@
   },
   {
     "githubUrl": "https://github.com/tamagui/tamagui/tree/master/code/ui/tamagui",
-    "npmPkg": "tamagui",
     "examples": ["https://tamagui.dev"],
     "images": [
       "https://raw.githubusercontent.com/tamagui/tamagui/master/code/tamagui.dev/public/social.png"
@@ -12686,9 +12685,6 @@
   {
     "githubUrl": "https://github.com/tamagui/tamagui/tree/main/code/core/animations-moti",
     "npmPkg": "@tamagui/animations-moti",
-    "examples": [
-      "https://tamagui.dev/docs/core/animations"
-    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -12698,9 +12694,6 @@
   {
     "githubUrl": "https://github.com/tamagui/tamagui/tree/main/code/core/animations-react-native",
     "npmPkg": "@tamagui/animations-react-native",
-    "examples": [
-      "https://tamagui.dev/docs/core/configuration"
-    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -12710,9 +12703,6 @@
   {
     "githubUrl": "https://github.com/tamagui/tamagui/tree/main/code/core/config",
     "npmPkg": "@tamagui/config",
-    "examples": [
-      "https://tamagui.dev/docs/core/configuration"
-    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -12722,9 +12712,6 @@
   {
     "githubUrl": "https://github.com/tamagui/tamagui/tree/main/code/core/shorthands",
     "npmPkg": "@tamagui/shorthands",
-    "examples": [
-      "https://tamagui.dev/docs/core/configuration#shorthands"
-    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -12734,9 +12721,6 @@
   {
     "githubUrl": "https://github.com/tamagui/tamagui/tree/main/code/core/themes",
     "npmPkg": "@tamagui/themes",
-    "examples": [
-      "https://tamagui.dev/docs/intro/themes"
-    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -12747,7 +12731,7 @@
     "githubUrl": "https://github.com/tamagui/tamagui/tree/main/code/ui/toast",
     "npmPkg": "@tamagui/toast",
     "examples": [
-      "https://tamagui.dev/ui/toast"
+      "https://github.com/tamagui/tamagui/blob/main/code/demos/src/ToastDemo.tsx"
     ],
     "ios": true,
     "android": true,


### PR DESCRIPTION
# 📝 Why & how

following up with #1654 

adding packages:
- `@tamagui/animations-moti,`
- `@tamagui/animations-react-native,`
- `@tamagui/babel-plugin,`
- `@tamagui/cli,`
- `@tamagui/config,`
- `@tamagui/shorthands,`
- `@tamagui/themes,`
- `@tamagui/toast`


to avoid this error messages with `npx expo-doctor@latest`

![CleanShot 2025-06-10 at 11 23 04](https://github.com/user-attachments/assets/8dce48de-f14a-41be-9f76-462a82d61e91)


# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**
