### PR TITLE
fix: preserve npm download data for scoped packages (fixes #1640)

### DIFF
--- a/scripts/build-and-score-data.ts
+++ b/scripts/build-and-score-data.ts
@@ -130,6 +130,9 @@ async function buildAndScoreData() {
   data = data.map(project => ({
     ...project,
     npm: {
+      // Keep existing npm data (for scoped packages processed individually)
+      ...project.npm,
+      // Add bulk query results (for regular packages)
       ...(downloadsList.find(entry => entry.name === project.npmPkg)?.npm ?? {}),
       // ...(downloadsListWeek.find(entry => entry.name === project.npmPkg)?.npm ?? {}),
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
Fixes #1640 - Download counts were not displaying for packages with `"@"` character (scoped packages) due to npm data being overwritten during bulk query merge. Scoped packages are processed individually but their npm data was being replaced with empty objects from the bulk results.
- Preserve existing npm data when merging bulk query results
- Ensures scoped packages retain their individually-fetched download stats
- Regular packages continue to work as before
---

<table>
  <tr>
    <td><img width="1217" alt="before_fix" src="https://github.com/user-attachments/assets/6c819468-35a1-4aa9-9786-a9cc455e5193" /></td>
    <td><img width="1217" alt="after_fix" src="https://github.com/user-attachments/assets/09f01024-ff2a-4295-a4ac-a978c36e1391" /></td>
  </tr>
  <tr>
    <td align="center">Before: download count is missing</td>
    <td align="center">After: download count is displayed</td>
  </tr>
</table>

---

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a feature or fixed a bug -->
- [x] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
