### PR TITLE
correct internal link behaviour, tweak trending mark

### DIFF
--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -124,22 +124,22 @@ type AProps = PropsWithChildren<{
   hoverStyle?: TextStyles;
 }>;
 
-export const A = ({ href, target = '_blank', children, style, hoverStyle, ...rest }: AProps) => {
+export const A = ({ href, target, children, style, hoverStyle, ...rest }: AProps) => {
   const { isDark } = useContext(CustomAppearanceContext);
   const [isHovered, setIsHovered] = useState(false);
 
   const linkStyles = getLinkStyles(isDark);
   const linkHoverStyles = getLinkHoverStyles(isDark);
 
-  if (target === '_self' && !href.startsWith('#')) {
+  if (target === '_self' && !href.startsWith('#') || href.startsWith('/')) {
+    const passedStyle = Array.isArray(style) ? StyleSheet.flatten(style) : style;
     return (
       <Link
-        {...rest}
         href={href}
         style={{
           ...linkStyles,
           ...(isHovered && linkHoverStyles),
-          ...(style as any),
+          ...passedStyle as any,
           ...(isHovered && hoverStyle),
         }}>
         {children}
@@ -152,8 +152,8 @@ export const A = ({ href, target = '_blank', children, style, hoverStyle, ...res
       <HtmlElements.A
         {...rest}
         href={href}
-        target={target}
-        hrefAttrs={{ target }}
+        target={target ?? '_blank'}
+        hrefAttrs={{ target: target ?? '_blank' }}
         style={[linkStyles, isHovered && linkHoverStyles, style, isHovered && hoverStyle]}>
         {children}
       </HtmlElements.A>

--- a/components/Library/TrendingMark.tsx
+++ b/components/Library/TrendingMark.tsx
@@ -32,7 +32,7 @@ const TrendingMark = ({ library, style, markOnly = false }: Props) => {
           styles.popularityScore,
           {
             color: popularityStyles.backgroundColor,
-            marginBottom: markOnly ? 0 : 6,
+            marginVertical: markOnly ? -1 : 2,
             fontSize: markOnly ? 15 : 12,
           },
         ]}>
@@ -119,8 +119,9 @@ const styles = StyleSheet.create({
   scoringLink: {
     textDecorationLine: 'none',
     position: 'relative',
-    lineHeight: 18,
     backgroundColor: 'none',
+    display: 'flex',
+    alignItems: 'flex-start',
   },
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

After latest changes some internal links started to open in new tab, instead of navigating to the page within same tab.

This PR fixes that behaviour, and also alters the `TrendingMark` styles slightly so they are correctly rendered when wrapped in `next/link` component.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
