### PR TITLE
Update expo-roomplan metadata to include new architecture

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16711,7 +16711,8 @@
     ],
     "ios": true,
     "android": false,
-    "web": false
+    "web": false,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/donni106/matomo-tracker-react-native",


### PR DESCRIPTION
# 📝 Why & how
My Expo module uses the new architecture with turbo modules, and I updated the metadata here to reflect that.

# ✅ Checklist
- [X] Updated library in **`react-native-libraries.json`**
