### PR TITLE
update "posthog-react-native-session-replay" to enable newArchitecture flag

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14487,7 +14487,8 @@
       "https://github.com/PostHog/posthog-react-native-session-replay/tree/main/example"
     ],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture": true 
   },
   {
     "githubUrl": "https://github.com/pioner92/rn-fade-wrapper",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

I've tested the `posthog-react-native-session-replay` on two apps using the new architecture with expo SDK 53. It is working great in dev and production (4 months already in production). So I think we can consider it compatible with the new architecture.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**
