### PR TITLE
Add react-native-restart-newarch

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -17178,5 +17178,13 @@
     "npmPkg": "@pushpendersingh/react-native-otp-verify",
     "examples": ["https://github.com/pushpender-singh-ap/react-native-otp-verify/tree/main/example"],
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/ahmedawaad1804/react-native-restart-newarch",
+    "npmPkg": "react-native-restart-newarch",
+    "examples": ["https://github.com/ahmedawaad1804/react-native-restart-newarch/tree/main/example"],
+    "android": true,
+    "ios": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION

# 📝 Why & how
This library provides a simple API to **restart a React Native app**, fully compatible with the **New Architecture** (TurboModules).  
It supports both **iOS** and **Android**, and is ideal for apps using any runtime configuration resets.


# ✅ Checklist
- [x] Added library to **`react-native-libraries.json`**
