### PR TITLE
Added react-native-apns-kit and react-native-app-attest and updated r…

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -17285,7 +17285,6 @@
     "githubUrl": "https://github.com/Gautham495/react-native-play-age-signals",
     "examples": ["https://github.com/Gautham495/react-native-play-age-signals/tree/main/example"],
     "android": true,
-    "ios": false,
     "newArchitecture": true
   },
   {


### PR DESCRIPTION
This update adds two new React Native TurboModules and updates my other library react-native-play-age-signals tag from iOS to Android.

react-native-app-attest — provides a JavaScript bridge to Apple’s App Attest API (DeviceCheck framework), allowing React Native apps and App Clips to generate cryptographic keys, perform attestation, and create assertions to securely verify app integrity with a backend server.

react-native-apns-kit — provides a simple, direct bridge to Apple Push Notification Service (APNs), enabling iOS apps and App Clips to request notification permissions and retrieve the device token for backend push registration without third-party SDKs.

react-native-play-age-signals — Updated tag from iOS to Android.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed an issue or created the feature.
