### PR TITLE
Updated react-native-play-age-range-declaration package name

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -17286,9 +17286,10 @@
     "ios": true
   },
   {
-    "githubUrl": "https://github.com/Gautham495/react-native-play-age-signals",
-    "examples": ["https://github.com/Gautham495/react-native-play-age-signals/tree/main/example"],
+    "githubUrl": "https://github.com/Gautham495/react-native-play-age-range-declaration",
+    "examples": ["https://github.com/Gautham495/react-native-play-age-range-declaration/tree/main/example"],
     "android": true,
+    "ios": true,
     "newArchitecture": true
   },
   {


### PR DESCRIPTION
Updated library name from react-native-play-age-signals to react-native-play-age-range-declaration manage both Android & iOS Play Age Signal and Declared Age APIs.

Before it was only for Android and now it is for both.

It now uses Nitro Modules from Turbo Modules and I removed all of the Obj C code as I was having build issues.

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed an issue or created the feature.
