### PR TITLE
add and cleanup libraries entries after adding config plugins support

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14886,7 +14886,8 @@
     "npmPkg": "@ua/react-native-airship",
     "examples": ["https://github.com/urbanairship/react-native-airship/tree/main/example"],
     "ios": true,
-    "android": true
+    "android": true,
+    "configPlugin": "https://github.com/urbanairship/airship-expo-plugin"
   },
   {
     "githubUrl": "https://github.com/prisma/react-native-prisma",
@@ -17692,11 +17693,9 @@
     "configPlugin": "https://github.com/chronsyn/react-native-keyevent-expo-config-plugin"
   },
   {
-    "githubUrl": "https://github.com/urbanairship/react-native-airship",
-    "npmPkg": "@ua/react-native-airship",
-    "examples": ["https://github.com/urbanairship/react-native-airship/tree/main/example"],
+    "githubUrl": "https://github.com/EdgeApp/react-native-airship",
+    "examples": ["https://github.com/EdgeApp/react-native-airship/tree/master/AirshipDemo"],
     "ios": true,
-    "android": true,
-    "configPlugin": "https://github.com/urbanairship/airship-expo-plugin"
+    "android": true
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

This PR adds the following entries to the directory:
* https://github.com/adjust/react_native_sdk
* https://github.com/idearockers/react-native-dynamic-app-icon
* https://github.com/computools/react-native-dynamic-app-icon
* https://github.com/Leanplum/Leanplum-ReactNative-SDK
* https://github.com/MetaMask/react-native-search-api
* https://github.com/jdmunro/react-native-spotlight-search
* https://github.com/microsoft/appcenter-sdk-react-native/tree/develop/appcenter
* https://github.com/microsoft/appcenter-sdk-react-native/tree/develop/appcenter-analytics
* https://github.com/microsoft/appcenter-sdk-react-native/tree/develop/appcenter-crashes
* https://github.com/kevinejohn/react-native-keyevent
* https://github.com/EdgeApp/react-native-airship

I have also removed two stand-alone entries of config plugins packages, since they are already present and linked with base packages. Additionally, one package has been updated with third-party config plugin.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**
