### PR TITLE
add packages to the list

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -17697,5 +17697,34 @@
     "examples": ["https://github.com/EdgeApp/react-native-airship/tree/master/AirshipDemo"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/expo/expo/tree/main/packages/patch-project",
+    "ios": true,
+    "android": true,
+    "tvos": true,
+    "fireos": true,
+    "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/WookieFPV/typed-config-plugins",
+    "ios": true,
+    "android": true,
+    "dev": true,
+    "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/WookieFPV/expo-build-disk-cache",
+    "ios": true,
+    "android": true,
+    "dev": true,
+    "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/WookieFPV/list-config-plugins",
+    "ios": true,
+    "android": true,
+    "dev": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
Added a few libaries:

- patch-project (from expo, its like patch-package but as config plugin)
- list-config-plugins (a cli tool to list all packages with config plugin for the users app)
- expo-build-disk-cache (lokal build caching for expo app builds)
- typed-config-plugins (adds type safety for expo Config plugin in app.config.ts)

I am not 100% sure on some properties cause some of those are dev tools.
For example does config-plugins work on tvos / fireos ? I think they should work there but not sure

# ✅ Checklist
- [X] Added library to **`react-native-libraries.json`**
