### PR TITLE
Add react-native-nitro-sfsymbols library details

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -17731,19 +17731,6 @@
     "newArchitecture": true
   },
   {
-    "githubUrl": "https://github.com/mCodex/react-native-nitro-sfsymbols",
-    "npmPkg": "react-native-nitro-sfsymbols",
-    "examples": [
-      "https://github.com/mCodex/react-native-nitro-sfsymbols/tree/main/example"
-    ],
-    "images": ["https://github.com/mCodex/react-native-nitro-sfsymbols/blob/main/example.gif?raw=true"],
-    "ios": true,
-    "macos": true,
-    "tvos": true,
-    "visionos": true,
-    "newArchitecture": true
-  },
-  {
     "githubUrl": "https://github.com/orcunorcun/react-native-cookie-handler",
     "npmPkg": "react-native-cookie-handler",
     "examples": [
@@ -17751,5 +17738,18 @@
     ],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/mCodex/react-native-nitro-sfsymbols",
+    "npmPkg": "react-native-nitro-sfsymbols",
+    "examples": [
+      "https://github.com/mCodex/react-native-nitro-sfsymbols/tree/main/example"
+    ],
+    "images": ["https://raw.githubusercontent.com/mCodex/react-native-nitro-sfsymbols/refs/heads/main/example.gif"],
+    "ios": true,
+    "macos": true,
+    "tvos": true,
+    "visionos": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This pull request adds a new library to the `react-native-libraries.json` file. The new entry provides metadata for `react-native-nitro-sfsymbols`, including platform support and example resources.

Library addition:

* Added `react-native-nitro-sfsymbols` to `react-native-libraries.json`, including its GitHub URL, NPM package name, example link, image, and supported platforms (`ios`, `macos`, `tvos`, `visionos`).


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed an issue or created the feature.
