### PR TITLE
add few libs from earlier PRs

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -17870,5 +17870,35 @@
     "ios": true,
     "android": true,
     "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/gluestack/gluestack-ui/tree/main/packages/gluestack-core",
+    "npmPkg": "@gluestack-ui/core",
+    "ios": true,
+    "android": true,
+    "web": true
+  },
+  {
+    "githubUrl": "https://github.com/gluestack/gluestack-ui/tree/main/packages/gluestack-utils",
+    "npmPkg": "@gluestack-ui/utils",
+    "ios": true,
+    "android": true,
+    "web": true
+  },
+  {
+    "githubUrl": "https://github.com/gluestack/gluestack-ui/tree/main/packages/ui-next-adapter",
+    "npmPkg": "@gluestack/ui-next-adapter",
+    "web": true
+  },
+  {
+    "githubUrl": "https://github.com/facebook/metro/tree/main/packages/metro",
+    "ios": true,
+    "android": true,
+    "macos": true,
+    "tvos": true,
+    "visionos": true,
+    "web": true,
+    "windows": true,
+    "dev": true
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

This PR adds libraries previously proposed in other PR, but never landed:
* https://github.com/gluestack/gluestack-ui/tree/main/packages/gluestack-core
* https://github.com/gluestack/gluestack-ui/tree/main/packages/gluestack-utils
* https://github.com/gluestack/gluestack-ui/tree/main/packages/ui-next-adapter
* https://github.com/facebook/metro/tree/main/packages/metro

Supersedes:
* #1636
* #1222 (see Manual installation - https://gluestack.io/ui/docs/home/getting-started/installation)

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
