### PR TITLE
add "Recently Released" sort option

### DIFF
--- a/components/Sort.tsx
+++ b/components/Sort.tsx
@@ -29,6 +29,10 @@ const sorts: { param: QueryOrder; label: string }[] = [
     label: 'Recently Added',
   },
   {
+    param: 'released',
+    label: 'Recently Released',
+  },
+  {
     param: 'quality',
     label: 'Quality',
   },

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="next" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -22,6 +22,7 @@ function getData(): SortedDataType {
     relevance: Sorting.relevance([...originalData]),
     size: Sorting.bundleSize([...originalData]),
     dependencies: Sorting.dependencies([...originalData]),
+    released: Sorting.released([...originalData]),
   };
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -49,7 +49,7 @@ input:focus-visible  {
 
 select {
   display: flex;
-  min-width: 140px;
+  min-width: 156px;
   height: 24px;
   align-items: center;
   cursor: pointer;

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,6 +4,7 @@ export type QueryOrder =
   | 'relevance'
   | 'updated'
   | 'added'
+  | 'released'
   | 'quality'
   | 'popularity'
   | 'issues'

--- a/util/sorting.ts
+++ b/util/sorting.ts
@@ -25,6 +25,17 @@ export function updated(libraries: LibraryType[]) {
   });
 }
 
+export function released(libraries: LibraryType[]) {
+  return libraries.sort((a, b) => {
+    if (a?.npm?.latestReleaseDate && b?.npm?.latestReleaseDate) {
+      return (
+        new Date(b.npm.latestReleaseDate).getTime() - new Date(a.npm.latestReleaseDate).getTime()
+      );
+    }
+    return 0;
+  });
+}
+
 export function quality(libraries: LibraryType[]) {
   return libraries.sort((a, b) => b.score - a.score);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Refs https://github.com/react-native-community/directory/issues/188#issuecomment-2303601941

This PR adds the new "Recently Released" sort option, which is possible now since we fetch an additional release data from npm registry.

# ✅ Checklist

- [x] Documented in this PR how you fixed an issue or created the feature.
