### PR TITLE
chore: added react-native-speech-recognition-kit

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -18078,5 +18078,14 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/Gautham495/react-native-speech-recognition-kit",
+    "examples": [
+      "https://github.com/Gautham495/react-native-speech-recognition-kit/tree/main/example"
+    ],
+    "android": true,
+    "ios": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Added a library called react-native-speech-recognition-kit as there is no available speech to text (STT) libraries available in react native which runs on Bare React Native.

This library works on both Expo and Bare as it does not use Expo Modules and is built with Turbo Modules.

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed an issue or created the feature.
