### PR TITLE
Fix GitHub button links in tools page

### DIFF
--- a/pages/tools.tsx
+++ b/pages/tools.tsx
@@ -131,10 +131,7 @@ function GitHubButton({ href }: GitHubButtonProps) {
     backgroundColor: isDark ? darkColors.primaryDark : colors.primary,
   };
   return (
-    <Button
-      openInNewTab
-      href="https://github.com/raycast/extensions/tree/main/extensions/react-native-directory"
-      style={[styles.button, primaryButtonColorStyle]}>
+    <Button openInNewTab href={href} style={[styles.button, primaryButtonColorStyle]}>
       <GitHub width={16} />
       <P style={styles.githubButtonLabel}>GitHub</P>
     </Button>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
Found a bug on the tools page where all GitHub buttons were linking to the Raycast repository instead of their respective repos. 
Fixed by using the `href` prop instead of the hardcoded URL.

# ✅ Checklist

<!-- If you added a feature or fixed a bug -->
- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.

<!-- Thanks again for helping improve the project! 🙏 -->
