### PR TITLE
Add react-native-otp-input to libraries list

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -18391,8 +18391,8 @@
     "https://github.com/bhojaniasgar/react-native-otp-input/tree/main/example/expo"
     ],
     "ios": true,
-  "android": true,
-  "web": true,
-  "newArchitecture": true
+    "android": true,
+    "web": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Included @bhojaniasgar/react-native-otp-input in react-native-libraries.json with relevant metadata and example links. The library supports iOS, Android, web, and the new architecture.

<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->
- [x] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented how you found or replicated the issue.
- [ ] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
