### PR TITLE
fix duplicated topics keywords in rare cases

### DIFF
--- a/scripts/fetch-github-data.ts
+++ b/scripts/fetch-github-data.ts
@@ -137,7 +137,7 @@ function createRepoDataWithResponse(json: any, monorepo: boolean): LibraryType['
 
       if (monorepo) {
         json.homepageUrl = packageJson.homepage;
-        json.topics = processTopics(packageJson.keywords);
+        json.topics = [...new Set(processTopics(packageJson.keywords))];
         json.description = packageJson.description;
         json.licenseInfo = getLicenseFromPackageJson(packageJson);
       }

--- a/scripts/helpers.ts
+++ b/scripts/helpers.ts
@@ -56,11 +56,12 @@ export function processTopics(topics?: string[]) {
   return topics
     .map(topic =>
       topic
+        .normalize('NFKC')
+        .toLowerCase()
         .replace(/([ _])/g, '-')
         .replace(STOPWORDS_PATTERN, '')
         .replace(/-+/g, '-')
         .replace(/^-|-$/g, '')
-        .toLowerCase()
         .trim()
     )
     .filter(topic => topic?.length);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Why working on packages details pages I have spotted that in rare cases we can have duplicated topics keywords for packages in monorepo.

This PR fixes that problem, but changing a bit how we process topics, and also used Set to deduplicate processed strings. The changes have been tested by adding a previously problematic entry to `debug-github-repos.json` and re-fetching data locally.

# ✅ Checklist

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [x] Described how to use or verify the change.
