### PR TITLE
add fallback for npm-stat requests, improve data fallback, improve logs

### DIFF
--- a/scripts/fetch-npm-download-data.ts
+++ b/scripts/fetch-npm-download-data.ts
@@ -19,7 +19,7 @@ export async function fetchNpmDownloadData(pkgData: LibraryType, attemptsCount =
 
     if (response.status !== 200) {
       console.error(
-        `[NPM DOWNLOADS API] npm API has returned invalid response - status ${response.status}!`
+        `⬇️ [NPM DOWNLOADS API] npm API has returned invalid response - status ${response.status}!`
       );
       return { ...pkgData, npm: null };
     }
@@ -28,7 +28,7 @@ export async function fetchNpmDownloadData(pkgData: LibraryType, attemptsCount =
 
     if (!downloadData.package) {
       console.warn(
-        `[NPM DOWNLOADS API] ${npmPkg} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
+        `⬇️ [NPM DOWNLOADS API] ${npmPkg} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
       );
       return { ...pkgData, npm: null };
     }
@@ -41,12 +41,12 @@ export async function fetchNpmDownloadData(pkgData: LibraryType, attemptsCount =
     };
   } catch (error) {
     if (attemptsCount >= ATTEMPTS_LIMIT) {
-      console.error('[NPM DOWNLOADS API] Looks like we have reached the npm API rate limit!');
+      console.error('⬇️ [NPM DOWNLOADS API] Looks like we have reached the npm API rate limit!');
       console.error(error);
       return { ...pkgData, npm: null };
     }
     await sleep(REQUEST_SLEEP, REQUEST_SLEEP * 2);
-    console.log(`[NPM DOWNLOADS API] Retrying fetch for ${npmPkg} (${attemptsCount + 1})`);
+    console.log(`⬇️ [NPM DOWNLOADS API] Retrying fetch for ${npmPkg} (${attemptsCount + 1})`);
     return await fetchNpmDownloadData(pkgData, attemptsCount + 1);
   }
 }
@@ -58,7 +58,7 @@ export async function fallbackFetchNpmDownloadData(name: string) {
 
     if (monthlyResponse.status !== 200) {
       console.error(
-        `[NPM DOWNLOADS API] npm API has returned invalid response - status ${monthlyResponse.status}!`
+        `⬇️ [NPM DOWNLOADS API] npm API has returned invalid response - status ${monthlyResponse.status}!`
       );
       return { name, npm: null };
     }
@@ -67,7 +67,7 @@ export async function fallbackFetchNpmDownloadData(name: string) {
 
     if (!monthlyDownloadData.package) {
       console.warn(
-        `[NPM DOWNLOADS API] ${name} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
+        `⬇️ [NPM DOWNLOADS API] ${name} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
       );
       return { name, npm: null };
     }
@@ -77,7 +77,7 @@ export async function fallbackFetchNpmDownloadData(name: string) {
 
     if (weeklyResponse.status !== 200) {
       console.error(
-        `[NPM DOWNLOADS API] npm API has returned invalid response - status ${weeklyResponse.status}!`
+        `⬇️ [NPM DOWNLOADS API] npm API has returned invalid response - status ${weeklyResponse.status}!`
       );
       return { name, npm: null };
     }
@@ -86,7 +86,7 @@ export async function fallbackFetchNpmDownloadData(name: string) {
 
     if (!weeklyDownloadData.package) {
       console.warn(
-        `[NPM DOWNLOADS API] ${name} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
+        `⬇️ [NPM DOWNLOADS API] ${name} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
       );
       return { name, npm: null };
     }
@@ -99,7 +99,7 @@ export async function fallbackFetchNpmDownloadData(name: string) {
       },
     };
   } catch (error) {
-    console.error('[NPM DOWNLOADS API] Looks like we have reached the npm API rate limit!');
+    console.error('⬇️ [NPM DOWNLOADS API] Looks like we have reached the npm API rate limit!');
     console.error(error);
     return { name, npm: null };
   }

--- a/scripts/fetch-npm-registry-data.ts
+++ b/scripts/fetch-npm-registry-data.ts
@@ -24,7 +24,7 @@ export async function fetchNpmRegistryData(
 
     if (response.status !== 200) {
       console.error(
-        `[NPM REGISTRY API] npm API has returned invalid response - status ${response.status}!`
+        `📦 [NPM REGISTRY API] npm API has returned invalid response - status ${response.status}!`
       );
       return pkgData;
     }
@@ -33,7 +33,7 @@ export async function fetchNpmRegistryData(
 
     if (!registryData._id) {
       console.warn(
-        `[NPM REGISTRY API] ${npmPkg} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
+        `📦 [NPM REGISTRY API] ${npmPkg} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
       );
       return pkgData;
     }
@@ -42,7 +42,7 @@ export async function fetchNpmRegistryData(
 
     if (!latestRelease) {
       console.warn(
-        `[NPM REGISTRY API] ${npmPkg} doesn't have the "latest" tag, skipping bundle size!`
+        `📦 [NPM REGISTRY API] ${npmPkg} doesn't have the "latest" tag, skipping bundle size!`
       );
       return pkgData;
     }
@@ -62,12 +62,12 @@ export async function fetchNpmRegistryData(
     };
   } catch (error) {
     if (attemptsCount >= ATTEMPTS_LIMIT) {
-      console.error('[NPM REGISTRY API] Looks like we have reach the npm API rate limit!');
+      console.error('📦 [NPM REGISTRY API] Looks like we have reach the npm API rate limit!');
       console.error(error);
       return pkgData;
     }
     await sleep(REQUEST_SLEEP, REQUEST_SLEEP * 2);
-    console.log(`[NPM REGISTRY API] Retrying fetch for ${npmPkg} (${attemptsCount + 1})`);
+    console.log(`📦 [NPM REGISTRY API] Retrying fetch for ${npmPkg} (${attemptsCount + 1})`);
     return await fetchNpmRegistryData(pkgData, attemptsCount + 1);
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Looks like after yesterday Cloudflare outage npm-stats API become a bit unstable, and lacks data for big chunk of packages. It seems that the data are re-fetch on first request, so I have added a single query fallback, which should have higher success rate than initial bulk query.

In the process I have also improved the data backfill fallback based on previous data stored in Vercel Blob Storage, and improved the logs a bit, so it's easier to spot warn/error messages.

# ✅ Checklist

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
