### PR TITLE
reduce the npm-stats chunk size, remove closed source libs

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -17316,48 +17316,6 @@
     "expoGo": true
   },
   {
-    "githubUrl": "https://github.com/LovesWorking/react-native-buoy/tree/main/packages/devtools-floating-menu",
-    "npmPkg": "@react-buoy/core",
-    "examples": ["https://github.com/LovesWorking/react-native-buoy/tree/main/example"],
-    "ios": true,
-    "android": true
-  },
-  {
-    "githubUrl": "https://github.com/LovesWorking/react-native-buoy/tree/main/packages/shared",
-    "npmPkg": "@react-buoy/shared-ui",
-    "examples": ["https://github.com/LovesWorking/react-native-buoy/tree/main/example"],
-    "ios": true,
-    "android": true
-  },
-  {
-    "githubUrl": "https://github.com/LovesWorking/react-native-buoy/tree/main/packages/env-tools",
-    "npmPkg": "@react-buoy/env",
-    "examples": ["https://github.com/LovesWorking/react-native-buoy/tree/main/example"],
-    "ios": true,
-    "android": true
-  },
-  {
-    "githubUrl": "https://github.com/LovesWorking/react-native-buoy/tree/main/packages/network",
-    "npmPkg": "@react-buoy/network",
-    "examples": ["https://github.com/LovesWorking/react-native-buoy/tree/main/example"],
-    "ios": true,
-    "android": true
-  },
-  {
-    "githubUrl": "https://github.com/LovesWorking/react-native-buoy/tree/main/packages/react-query",
-    "npmPkg": "@react-buoy/react-query",
-    "examples": ["https://github.com/LovesWorking/react-native-buoy/tree/main/example"],
-    "ios": true,
-    "android": true
-  },
-  {
-    "githubUrl": "https://github.com/LovesWorking/react-native-buoy/tree/main/packages/storage",
-    "npmPkg": "@react-buoy/storage",
-    "examples": ["https://github.com/LovesWorking/react-native-buoy/tree/main/example"],
-    "ios": true,
-    "android": true
-  },
-  {
     "githubUrl": "https://github.com/margelo/react-native-nitro-fetch/tree/main/package",
     "npmPkg": "react-native-nitro-fetch",
     "examples": ["https://github.com/margelo/react-native-nitro-fetch/tree/main/example"],
@@ -18501,7 +18459,6 @@
   {
     "githubUrl": "https://github.com/riteshshukla04/react-native-nitro-ota",
     "android": true,
-    "npmPkg": "react-native-nitro-ota",
     "ios": true,
     "newArchitecture": true
   },

--- a/scripts/build-and-score-data.ts
+++ b/scripts/build-and-score-data.ts
@@ -34,6 +34,7 @@ const DATA_PATH = path.resolve('assets', 'data.json');
 const CHECK_DATA_PATH = path.resolve('assets', 'check-data.json');
 
 const CHUNK_SIZE = 25;
+const NPM_STATS_CHUNK_SIZE = 10;
 const SLEEP_TIME = 250;
 
 const invalidRepos: string[] = [];
@@ -99,8 +100,8 @@ async function buildAndScoreData() {
   });
 
   // Assemble and fetch packages data in bulk queries
-  const bulkList = [...Array(Math.ceil(fetchList.length / CHUNK_SIZE))].map(_ =>
-    fetchList.splice(0, CHUNK_SIZE)
+  const bulkList = [...Array(Math.ceil(fetchList.length / NPM_STATS_CHUNK_SIZE))].map(_ =>
+    fetchList.splice(0, NPM_STATS_CHUNK_SIZE)
   );
 
   const downloadsList = await fetchNpmStatDataSequentially(bulkList);
@@ -393,7 +394,7 @@ async function fetchNpmStatDataSequentially(bulkList: string[][]) {
     console.log(`Sleeping ${SLEEP_TIME}ms`);
 
     const data = await fetchNpmStatDataBulk(chunk);
-    console.log(`${CHUNK_SIZE * (chunkIndex + 1)} of ${total} fetched`);
+    console.log(`${NPM_STATS_CHUNK_SIZE * (chunkIndex + 1)} of ${total} fetched`);
 
     results.push(...data);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Look like npm-stats API reduced the maximum packages per query allowed, which resulted in fetch fails during deployment.

Additionally, I have removed the `react-native-buoy` packages which seems to be migrated from OSS repository to private ones.

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**
- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
