### PR TITLE
add: rn-hide-home-indicator library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -18566,5 +18566,12 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/notixit/rn-hide-home-indicator",
+    "npmPkg": "rn-hide-home-indicator",
+    "examples": ["https://github.com/notixit/rn-hide-home-indicator"],
+    "ios": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds a new library, **rn-hide-home-indicator**, to the React Native libraries directory.  
The library provides a simple API for hiding the iOS home indicator and includes support for the New Architecture.  
A new entry has been added to `react-native-libraries.json` with all required fields.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
