### PR TITLE
Add new library entry for expo-stream-audio

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -18583,7 +18583,6 @@
     "githubUrl": "https://github.com/vLaD1m1r99/expo-stream-audio",
     "ios": true,
     "android": true,
-    "expoGo": false,
     "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

  Adding `expo-stream-audio` - an Expo module that enables audio streaming for real-time audio features like live transcription.

  The package supports iOS and Android platforms, uses Expo Modules API (New Architecture compatible), and requires a custom dev client (not compatible with
  Expo Go).

  - npm: https://www.npmjs.com/package/expo-stream-audio
  - GitHub: https://github.com/vLaD1m1r99/expo-stream-audio

  # ✅ Checklist

  - [x] Added library to **`react-native-libraries.json`**