### PR TITLE
Add newArchitecture flag to react-native-nitro-http-server

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -18522,7 +18522,6 @@
   },
   {
     "githubUrl": "https://github.com/iwater/react-native-nitro-http-server",
-    "npmPkg": "react-native-nitro-http-server",
     "ios": true,
     "android": true,
     "newArchitecture": true


### PR DESCRIPTION
# 📝 Why & how

Add newArchitecture flag to react-native-nitro-http-server

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**