### PR TITLE
add expo-gaode-map

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -18701,14 +18701,13 @@
     "newArchitecture": true
   },
   {
-  "githubUrl": "https://github.com/TomWq/expo-gaode-map/tree/main/packages/core",
-  "npmPkg": "expo-gaode-map",
-  "examples": [
-    "https://github.com/TomWq/expo-gaode-map-example"
-  ],
-  "ios": true,
-  "android": true,
-  "newArchitecture": true
-}
-
+    "githubUrl": "https://github.com/TomWq/expo-gaode-map/tree/main/packages/core",
+    "npmPkg": "expo-gaode-map",
+    "examples": [
+      "https://github.com/TomWq/expo-gaode-map-example"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
+  }
 ]


### PR DESCRIPTION
This PR adds **expo-gaode-map** to the React Native Directory.

**What is expo-gaode-map?**
- A comprehensive AMap (高德地图/Gaode Map) component library for React Native
- Built with Expo Modules API for better type safety and developer experience
- Provides map display, location services, overlays, search, navigation, and Web API features
- Organized as a monorepo with multiple packages for different functionalities

**Key Features:**
- ✅ Full map functionality (multiple map types, gestures, camera controls)
- ✅ Precise location services (continuous/single location, coordinate conversion)
- ✅ Rich overlays (Circle, Marker, Polyline, Polygon, HeatMap, Cluster, etc.)
- ✅ Complete TypeScript type definitions
- ✅ Cross-platform support (Android & iOS)
- ✅ Supports both React Native architectures (Paper & Fabric)
- ✅ Config Plugin for easy setup

**Optional Modules:**
- 🔍 Search module (expo-gaode-map-search) - POI search, geocoding
- 🧭 Navigation module (expo-gaode-map-navigation) - Route planning, real-time navigation
- 🌐 Web API module (expo-gaode-map-web-api) - Pure JavaScript implementation

**Documentation:**
- 📖 [Online Documentation](https://TomWq.github.io/expo-gaode-map/)
- 💻 [Example Repository](https://github.com/TomWq/expo-gaode-map-example)
