### PR TITLE
Add Ultravox React Native SDK

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -18718,10 +18718,10 @@
     "newArchitecture": true
   },
   {
-    "githubUrl": "http://github.com/fixie-ai/ultravox-client-sdk-react-native",
+    "githubUrl": "https://github.com/fixie-ai/ultravox-client-sdk-react-native",
     "npmPkg": "ultravox-react-native",
     "examples": [
-      "http://github.com/fixie-ai/ultravox-client-sdk-react-native/tree/main/example"
+      "https://github.com/fixie-ai/ultravox-client-sdk-react-native/tree/main/example"
     ],
     "ios": true,
     "android": true,


### PR DESCRIPTION
# 📝 Why & how
[Ultravox](https://ultravox.ai) now has native support for React Native. This PR adds the relevant library to the React Native directory.

# ✅ Checklist

- [ x] Added library to **`react-native-libraries.json`**
