### PR TITLE
Add react-native-earl-gamepad to libraries list

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6,8 +6,8 @@
     "android": true,
     "expoGo": true,
     "images": [
-      "https://github.com/user-attachments/assets/dfebd8c5-7d9a-42c7-802b-2773ec8c8ae9",
-      "https://github.com/user-attachments/assets/7b37d76a-7695-4be9-bda4-7e3d1e6adf41"
+      "https://raw.githubusercontent.com/Swif7ify/react-native-earl-gamepad/main/images/visual_debugger.jpg",
+      "https://raw.githubusercontent.com/Swif7ify/react-native-earl-gamepad/main/images/visual_debugger_1.jpg"
     ]
   },
   {


### PR DESCRIPTION
Added new library entry for react-native-earl-gamepad.

<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

I am adding `react-native-earl-gamepad` to the directory. This is a WebView-based gamepad bridge that exposes buttons, analog sticks, the D-pad, and connection status events to the React Native JavaScript side.

Why: The current ecosystem for React Native gamepad support is largely outdated and unmaintained. Existing libraries often fail to work with modern React Native versions or lack support for standard controller mappings.

How: This library solves the issue by leveraging a hidden WebView to access the robust HTML5 Gamepad API, bridging those events back to React Native. This ensures better compatibility and a standardized API for handling input without relying on deprecated native modules.

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->
- [x] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented how you found or replicated the issue.
- [ ] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->