### PR TITLE
Add react-native-earl-gamepad to libraries list

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,17 +1,5 @@
 [
   {
-    "githubUrl": "https://github.com/Swif7ify/react-native-earl-gamepad",
-    "npmPkg": "react-native-earl-gamepad",
-    "ios": true,
-    "android": true,
-    "expoGo": true,
-    "images": [
-      "https://raw.githubusercontent.com/Swif7ify/react-native-earl-gamepad/main/images/visual_debugger.jpg",
-      "https://raw.githubusercontent.com/Swif7ify/react-native-earl-gamepad/main/images/2.jpg",
-      "https://raw.githubusercontent.com/Swif7ify/react-native-earl-gamepad/main/images/4.jpg"
-    ]
-  },
-  {
     "githubUrl": "https://github.com/onubo/react-native-logs",
     "ios": true,
     "android": true,
@@ -18823,5 +18811,16 @@
     "examples": ["https://github.com/msasinowski/react-native-expo-braintree/tree/main/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/Swif7ify/react-native-earl-gamepad",
+    "images": [
+      "https://raw.githubusercontent.com/Swif7ify/react-native-earl-gamepad/main/images/visual_debugger.jpg",
+      "https://raw.githubusercontent.com/Swif7ify/react-native-earl-gamepad/main/images/2.jpg",
+      "https://raw.githubusercontent.com/Swif7ify/react-native-earl-gamepad/main/images/4.jpg"
+    ],
+    "ios": true,
+    "android": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
Added new library entry for react-native-earl-gamepad with images.

<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Adding `react-native-earl-gamepad` to the directory.

**Why:** Existing React Native gamepad libraries are largely outdated, unmaintained, or incompatible with modern RN versions.

**How:** This library uses a WebView-based bridge to access the standard HTML5 Gamepad API, exposing buttons, axes, D-pad, and connection events to React Native with a modern hook-based API.

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->
- [x] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [x] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
