### PR TITLE
fix few issues related to READMEs rendering

### DIFF
--- a/components/Package/PackageAuthor.tsx
+++ b/components/Package/PackageAuthor.tsx
@@ -36,7 +36,10 @@ export default function PackageAuthor({ author, compact }: Props) {
             <View>
               <Caption style={labelStyle}>{ghUsername}</Caption>
               <span style={sublabelStyle}>
-                {author.replace(/\s*\(?https?:\/\/\S+\)?\s*/g, '').trim()}
+                {author
+                  .replace(/\s*\(?https?:\/\/\S+\)?\s*/g, '')
+                  .replace(/[<>()]/g, '')
+                  .trim()}
               </span>
             </View>
           </A>

--- a/components/Package/ReadmeBox.tsx
+++ b/components/Package/ReadmeBox.tsx
@@ -103,7 +103,12 @@ export default function ReadmeBox({ packageName, githubUrl, isTemplate, loader =
               a: (props: any) => {
                 if (props.href && !props.href.startsWith('//')) {
                   if (!props.href.startsWith('http')) {
-                    return <A {...props} href={`${githubUrl}/blob/HEAD/${props.href}`} />;
+                    return (
+                      <A
+                        {...props}
+                        href={`${githubUrl}/blob/HEAD/${props.href.startsWith('/') ? props.href.slice(1) : props.href}`}
+                      />
+                    );
                   }
                   return <A {...props} />;
                 }
@@ -146,12 +151,19 @@ export default function ReadmeBox({ packageName, githubUrl, isTemplate, loader =
                 />
               ),
               pre: ({ children }: any) => {
-                const langClass = children.props.className;
+                const langClass = children?.props?.className;
+                if (langClass) {
+                  return (
+                    <ReadmeCodeBlock
+                      code={children.props.children}
+                      lang={langClass ? (langClass.split('-')[1] ?? 'sh').toLowerCase() : 'sh'}
+                    />
+                  );
+                }
                 return (
-                  <ReadmeCodeBlock
-                    code={children.props.children}
-                    lang={langClass ? (langClass.split('-')[1] ?? 'sh').toLowerCase() : 'sh'}
-                  />
+                  <div style={tw`relative my-2`} className="readme-code-block">
+                    <pre className="shiki">{children}</pre>
+                  </div>
                 );
               },
               blockquote: ({ children }: any) => {

--- a/scenes/PackageOverviewScene.tsx
+++ b/scenes/PackageOverviewScene.tsx
@@ -64,7 +64,7 @@ export default function PackageOverviewScene({
             <ReadmeBoxWithLoading
               packageName={packageName}
               isTemplate={library.template ?? false}
-              githubUrl={library.githubUrl}
+              githubUrl={library.github.urls.repo}
             />
             {library.examples && library.examples.length > 0 && (
               <>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Check out the Sentry report and found few small issues related to README rendering.

This PR fixes the following bugs:
* 500 error when attempting to render raw HTML `<pre>` tags in README content
* incorrect relative README links for packages in monorepos
* not fully cleaned up author details when npm returns raw string

The changes have been tested by visiting problematic pages on locally run website and inspecting the root causes.

# ✅ Checklist

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [x] Described how to use or verify the change.
