### PR TITLE
fix search input desync with debounced query

### DIFF
--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -43,12 +43,6 @@ export default function Search({ query, total }: Props) {
     }
   }, [isApple]);
 
-  useEffect(() => {
-    if (inputRef?.current && !search) {
-      inputRef.current.clear();
-    }
-  }, [search]);
-
   const typingCallback = useDebouncedCallback((text: string) => {
     void replace(urlWithQuery('/', { ...query, search: text, offset: null }));
   }, 200);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Hopefully fixes #2096

Looks like when clearing a search input and retyping new value quickly within the debounce window (200ms) it might sometimes lead to query param and input value desync, due to `search` induced `useEffect` triggering before debounce ended. 

The `useEffect` block has been added few months ago due to desync caused by pressing homepage logo link, but after changes to  link element within Tailwind refactor this should no longer be a case, which made this update effect redundant.

# ✅ Checklist

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.

# Preview

https://react-native-directory-q94s4znsj-rndir.vercel.app/