### PR TITLE
Fix packages search input on mobile

### DIFF
--- a/components/QuickSearch.tsx
+++ b/components/QuickSearch.tsx
@@ -144,7 +144,7 @@ export default function QuickSearch({ style }: Props) {
             </View>
             <TextInput
               ref={inputRef}
-              id="search"
+              id="quick-search"
               autoComplete="off"
               onKeyPress={event => {
                 if ('key' in event) {

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -102,10 +102,7 @@ export default function Search({ query, total, style }: Props) {
               onBlur={() => setInputFocused(false)}
               onChangeText={typingCallback}
               placeholder="Search libraries..."
-              style={[
-                tw`h-12.5 font-sans pr-30 flex flex-1 rounded-md border-2 border-palette-gray5 bg-palette-gray6 p-4 text-xl text-white -outline-offset-2 dark:border-default dark:bg-dark`,
-                !isSmallScreen && tw`pl-11`,
-              ]}
+              style={tw`h-12.5 font-sans pr-30 flex flex-1 rounded-md border-2 border-palette-gray5 bg-palette-gray6 p-4 pl-11 text-xl text-white -outline-offset-2 dark:border-default dark:bg-dark`}
               defaultValue={search}
               placeholderTextColor={tw`text-palette-gray4`.color as ColorValue}
             />


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

The search input in the packages page has some overlapping issues with the magnifying glass icon.

To fix this I just matched the `<Search />` component style to that of `<QuickSearch />`:

| Before                                                                                                                                     | After                                                                                                                                     |
| ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="850" height="1986" alt="input_before" src="https://github.com/user-attachments/assets/804aa607-da7e-4ced-a175-43d83f609055" /> | <img width="850" height="1986" alt="input_after" src="https://github.com/user-attachments/assets/bccd73da-59fa-4cd9-9db0-653a026f1e55" /> |

I also updated the `id` for the quick search input since it was using the same value in both places.

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a feature or fixed a bug -->

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [x] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
