### PR TITLE
Add @vitrion/expo-state-mcp to directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20603,5 +20603,12 @@
     ],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/vitrionbv/expo-state-mcp",
+    "npmPkg": "@vitrion/expo-state-mcp",
+    "ios": true,
+    "android": true,
+    "dev": true
   }
 ]


### PR DESCRIPTION
## Summary
Adds [`@vitrion/expo-state-mcp`](https://www.npmjs.com/package/@vitrion/expo-state-mcp) — dev-only MCP bridge for inspecting **expo-sqlite** and **zustand** in Expo apps.

## Entry
- `npmPkg` set (repo name ≠ npm package name)
- `ios` / `android`: true
- `dev`: true

Fork used: **vitrionbv/react-native-directory** (fresh; `Acetyld/directory` could not be synced without `workflow` OAuth scope).

Made with [Cursor](https://cursor.com)