### PR TITLE
Add react-native-tdlib

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20610,5 +20610,16 @@
     "ios": true,
     "android": true,
     "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/vladlenskiy/react-native-tdlib",
+    "examples": [
+      "https://github.com/vladlenskiy/react-native-tdlib/tree/master/example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/vladlenskiy/react-native-tdlib/master/docs/images/example.gif"
+    ],
+    "ios": true,
+    "android": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20613,9 +20613,7 @@
   },
   {
     "githubUrl": "https://github.com/vladlenskiy/react-native-tdlib",
-    "examples": [
-      "https://github.com/vladlenskiy/react-native-tdlib/tree/master/example"
-    ],
+    "examples": ["https://github.com/vladlenskiy/react-native-tdlib/tree/master/example"],
     "images": [
       "https://raw.githubusercontent.com/vladlenskiy/react-native-tdlib/master/docs/images/example.gif"
     ],


### PR DESCRIPTION
Adds [react-native-tdlib](https://github.com/vladlenskiy/react-native-tdlib) — a React Native wrapper around the official [TDLib](https://github.com/tdlib/td) with prebuilt iOS (`xcframework`) and Android (`arm64-v8a`, `armeabi-v7a`, `x86_64`) binaries.

- npm: https://www.npmjs.com/package/react-native-tdlib
- Example app: https://github.com/vladlenskiy/react-native-tdlib/tree/master/example
- Platforms: iOS, Android