### PR TITLE
Add @antar/react-native-usage-stats to directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20641,5 +20641,19 @@
     "examples": ["https://github.com/palmcode-ae/expo-location-picker/tree/main/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/AntarMukhopadhyaya/react-native-usage-stats",
+    "npmPkg": "@antardev/react-native-usage-stats",
+    "images": [
+      "https://raw.githubusercontent.com/AntarMukhopadhyaya/react-native-usage-stats/main/images/demo1.png",
+      "https://raw.githubusercontent.com/AntarMukhopadhyaya/react-native-usage-stats/main/images/demo2.png",
+      "https://raw.githubusercontent.com/AntarMukhopadhyaya/react-native-usage-stats/main/images/demo3.png"
+    ],
+    "android": true,
+    "ios": false,
+    "web": false,
+    "expoGo": false,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds a lightweight Android UsageStats module for React Native with Expo dev client support.

# 📝 Why & how

This PR adds a new library that exposes Android's UsageStatsManager API to React Native.

It provides:
- App usage stats
- Usage events
- Aggregated usage data

The API is fully typed and works with Expo via custom dev builds.

# ✅ Checklist

- [x] Added library to `react-native-libraries.json`