### PR TITLE
Fix bookmark button on mobile

### DIFF
--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -52,10 +52,12 @@ export default function Library({
         skipSecondaryMetadata && tw`min-h-0`,
         library.unmaintained && tw`opacity-85`,
       ]}>
-      <BookmarkButton
-        bookmarkId={libName}
-        style={tw`absolute right-2.5 top-2.5 z-10 rounded border border-palette-gray2 p-1.5 dark:border-palette-gray6`}
-      />
+      {!isSmallScreen && (
+        <BookmarkButton
+          bookmarkId={libName}
+          style={tw`absolute right-2.5 top-2.5 z-10 rounded border border-palette-gray2 p-1.5 dark:border-palette-gray6`}
+        />
+      )}
       <View
         style={[
           tw`flex-1 p-4 pb-3 pl-5`,
@@ -104,6 +106,12 @@ export default function Library({
                 />
               </A>
             </HoverEffect>
+            {isSmallScreen && (
+              <BookmarkButton
+                bookmarkId={libName}
+                style={tw`rounded border border-palette-gray2 p-1.5 dark:border-palette-gray6`}
+              />
+            )}
           </View>
           {!showTrendingMark && !skipDate && !library.unmaintained && (
             <UpdatedAtView library={library} />

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -109,7 +109,7 @@ export default function Library({
             {isSmallScreen && (
               <BookmarkButton
                 bookmarkId={libName}
-                style={tw`ml-auto rounded border border-palette-gray2 p-1.5 dark:border-palette-gray6`}
+                style={tw`-mr-1 ml-auto rounded border border-palette-gray2 p-1.5 dark:border-palette-gray6`}
               />
             )}
           </View>

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -87,7 +87,7 @@ export default function Library({
         <View
           style={
             isSmallScreen
-              ? tw`flex-col justify-start gap-2 self-start`
+              ? tw`w-full flex-col justify-start gap-2 self-start`
               : tw`flex-row items-start justify-between gap-6`
           }>
           <View style={tw`flex-row items-center gap-1.5`}>
@@ -109,7 +109,7 @@ export default function Library({
             {isSmallScreen && (
               <BookmarkButton
                 bookmarkId={libName}
-                style={tw`rounded border border-palette-gray2 p-1.5 dark:border-palette-gray6`}
+                style={tw`ml-auto rounded border border-palette-gray2 p-1.5 dark:border-palette-gray6`}
               />
             )}
           </View>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

There is an overlap between the GitHub and Bookmark buttons on mobile.

I fixed this by rendering separate `<BookmarkButton />` components depending on screen size:

| Before                                                                                                                                               | After                                                                                                                                               |
| ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="750" height="1732" alt="mobile_bookmark_before" src="https://github.com/user-attachments/assets/1a68539e-3d77-4c19-96dd-5e2d4af5ba71" /> | <img width="750" height="1732" alt="mobile_bookmark_after" src="https://github.com/user-attachments/assets/d2b49c53-f638-4466-823f-462771baebc0" /> |

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a feature or fixed a bug -->

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [x] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
