### PR TITLE
Add @carlos3g/element-dropdown

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20714,5 +20714,20 @@
     "examples": ["https://github.com/Azshar/react-native-tcard/tree/master/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/carlos3g/element-dropdown",
+    "npmPkg": "@carlos3g/element-dropdown",
+    "examples": ["https://github.com/carlos3g/element-dropdown/tree/master/example"],
+    "images": [
+      "https://raw.githubusercontent.com/hoaphantn7604/file-upload/master/document/dropdown/demo.gif",
+      "https://raw.githubusercontent.com/hoaphantn7604/file-upload/master/document/dropdown/example1.png",
+      "https://raw.githubusercontent.com/hoaphantn7604/file-upload/master/document/dropdown/example2.png"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [`@carlos3g/element-dropdown`](https://www.npmjs.com/package/@carlos3g/element-dropdown), a maintained fork of [`react-native-element-dropdown`](https://github.com/hoaphantn7604/react-native-element-dropdown). The original package has been effectively unmaintained since mid-2024 (186 open issues, 37 open PRs as of writing), so the fork exists to triage that backlog and keep the library shipping.

API is backward-compatible — for users on `react-native-element-dropdown` 2.12.x it's a drop-in: change the install name and import path, nothing else. There's a `compatibility.test.tsx` in the repo that pins that promise.

Pure JS, no native modules, so it works in Expo Go and on `react-native-web`. Already verified on the New Architecture.

Docs: https://carlos3g.github.io/element-dropdown/

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**