### PR TITLE
Parallelize SSR fetches on the home page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,47 +22,58 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     };
   }
 
-  const mostDownloadedResponse = await ssrFetch(
-    '/libraries',
-    {
-      order: 'downloads',
-      limit: LIMIT.toString(),
-      isMaintained: 'true',
-      hasNativeCode: 'true',
-    },
-    ctx
-  );
-  const recentlyAddedResponse = await ssrFetch(
-    '/libraries',
-    { order: 'added', limit: LIMIT.toString(), isMaintained: 'true' },
-    ctx
-  );
-  const recentlyUpdatedResponse = await ssrFetch(
-    '/libraries',
-    { order: 'updated', limit: LIMIT.toString(), isMaintained: 'true' },
-    ctx
-  );
-  const popularResponse = await ssrFetch(
-    '/libraries',
-    {
-      order: 'popularity',
-      limit: LIMIT.toString(),
-      isMaintained: 'true',
-      isPopular: 'true',
-      wasRecentlyUpdated: 'true',
-    },
-    ctx
-  );
+  const [
+    mostDownloadedResponse,
+    recentlyAddedResponse,
+    recentlyUpdatedResponse,
+    popularResponse,
+    statisticResponse,
+  ] = await Promise.all([
+    ssrFetch(
+      '/libraries',
+      {
+        order: 'downloads',
+        limit: LIMIT.toString(),
+        isMaintained: 'true',
+        hasNativeCode: 'true',
+      },
+      ctx
+    ),
+    ssrFetch('/libraries', { order: 'added', limit: LIMIT.toString(), isMaintained: 'true' }, ctx),
+    ssrFetch(
+      '/libraries',
+      { order: 'updated', limit: LIMIT.toString(), isMaintained: 'true' },
+      ctx
+    ),
+    ssrFetch(
+      '/libraries',
+      {
+        order: 'popularity',
+        limit: LIMIT.toString(),
+        isMaintained: 'true',
+        isPopular: 'true',
+        wasRecentlyUpdated: 'true',
+      },
+      ctx
+    ),
+    ssrFetch('/libraries/statistic', {}, ctx),
+  ]);
 
-  const statisticResponse = await ssrFetch('/libraries/statistic', {}, ctx);
+  const [mostDownloaded, recentlyAdded, recentlyUpdated, popular, statistic] = await Promise.all([
+    mostDownloadedResponse.json(),
+    recentlyAddedResponse.json(),
+    recentlyUpdatedResponse.json(),
+    popularResponse.json(),
+    statisticResponse.json(),
+  ]);
 
   return {
     props: {
-      mostDownloaded: await mostDownloadedResponse.json(),
-      recentlyAdded: await recentlyAddedResponse.json(),
-      recentlyUpdated: await recentlyUpdatedResponse.json(),
-      popular: await popularResponse.json(),
-      statistic: await statisticResponse.json(),
+      mostDownloaded,
+      recentlyAdded,
+      recentlyUpdated,
+      popular,
+      statistic,
     },
   };
 }


### PR DESCRIPTION
## Summary
- `pages/index.tsx` was awaiting five `ssrFetch` calls one after another inside `getServerSideProps`, then awaiting each `.json()` sequentially. The fetches don't depend on each other.
- Fan them out with `Promise.all` for both the requests and the JSON parses, so the waterfall collapses into a single roundtrip's worth of latency on the home page.

## Test plan
- [x] `bunx oxlint pages/index.tsx` — clean
- [x] `bunx oxfmt --check pages/index.tsx` — clean
- [x] `bun start` and load `/` locally; dev-server log shows the five `/api/libraries...` requests issued in the same window (~470ms each, overlapping) instead of stacked sequentially. Warm renders return in ~24-185ms with all five API calls completing in ~5-15ms each, in parallel. No runtime errors.