### PR TITLE
trim npm registry version data to reduce page size and load time

### DIFF
--- a/components/Package/VersionBox.tsx
+++ b/components/Package/VersionBox.tsx
@@ -6,7 +6,7 @@ import { DependencyIcon, DownloadIcon, PackageSizeIcon } from '~/components/Icon
 import TrustedBadge from '~/components/Package/TrustedBadge';
 import UserAvatar from '~/components/Package/UserAvatar';
 import RelativeTime from '~/components/RelativeTime';
-import { type NpmRegistryVersionData } from '~/types';
+import { type PackageVersionData } from '~/types';
 import { formatBytes } from '~/util/formatBytes';
 import { formatNumberToString, pluralize } from '~/util/strings';
 import tw from '~/util/tailwind';
@@ -14,7 +14,7 @@ import tw from '~/util/tailwind';
 type Props = {
   label?: string;
   time: string;
-  versionData: NpmRegistryVersionData;
+  versionData: PackageVersionData;
   downloads?: number;
 };
 

--- a/components/Package/VersionBox.tsx
+++ b/components/Package/VersionBox.tsx
@@ -72,7 +72,7 @@ export default function VersionBox({ label, time, versionData, downloads = 0 }: 
             <Label style={tw`font-light text-secondary`}>weekly downloads</Label>
           </View>
         </View>
-        {versionData.dist.unpackedSize && (
+        {versionData?.dist?.unpackedSize && (
           <View style={[tw`flex-row items-center gap-2.5`, !isSmallScreen && tw`min-w-[100px]`]}>
             <PackageSizeIcon style={tw`text-icon`} />
             <View>

--- a/components/Package/VersionDownloadsChart/index.tsx
+++ b/components/Package/VersionDownloadsChart/index.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Text, View } from 'react-native';
 
 import { Label } from '~/common/styleguide';
-import { type NpmPerVersionDownloads, type NpmRegistryData } from '~/types';
+import { type NpmPerVersionDownloads, type PackageVersionsData } from '~/types';
 import { replaceQueryParam } from '~/util/queryParams';
 import { formatNumberToString, pluralize } from '~/util/strings';
 import tw from '~/util/tailwind';
@@ -35,7 +35,7 @@ import VersionDownloadsChartModes from './VersionDownloadsChartModes';
 
 type Props = {
   npmDownloads: NpmPerVersionDownloads;
-  registryData: NpmRegistryData;
+  registryData: PackageVersionsData;
 };
 
 const DIST_TAG_LABEL_STYLE = {

--- a/components/Package/VersionDownloadsChart/utils.ts
+++ b/components/Package/VersionDownloadsChart/utils.ts
@@ -1,6 +1,6 @@
 import { clamp, sumBy } from 'es-toolkit/math';
 
-import { type NpmPerVersionDownloads, type NpmRegistryData } from '~/types';
+import { type NpmPerVersionDownloads, type PackageVersionsData } from '~/types';
 
 import {
   type AggregatedChartMode,
@@ -30,7 +30,7 @@ export function parseChartMode(value?: string | string[]) {
 
 export function buildBaseChartSeries(
   npmDownloads: NpmPerVersionDownloads,
-  registryData: NpmRegistryData,
+  registryData: PackageVersionsData,
   versionDistTags: Record<string, string[]>
 ) {
   return Object.entries(npmDownloads.downloads)
@@ -83,7 +83,7 @@ export function getLargestSeriesLength(chartSeriesByMode: ChartSeriesByMode) {
   return Math.max(...Object.values(chartSeriesByMode).map(series => series.length), 0);
 }
 
-export function mapVersionDistTags(registryData: NpmRegistryData) {
+export function mapVersionDistTags(registryData: PackageVersionsData) {
   return Object.entries(registryData['dist-tags']).reduce<Record<string, string[]>>(
     (acc, [tag, version]) => {
       acc[version] = [...(acc[version] ?? []), tag];

--- a/components/Package/VersionsSection.tsx
+++ b/components/Package/VersionsSection.tsx
@@ -7,7 +7,7 @@ import { Caption, H6Section, Label, useLayout } from '~/common/styleguide';
 import { Button } from '~/components/Button';
 import { SearchIcon } from '~/components/Icons';
 import InputKeyHint from '~/components/InputKeyHint';
-import { type NpmPerVersionDownloads, type NpmRegistryData } from '~/types';
+import { type NpmPerVersionDownloads, type PackageVersionsData } from '~/types';
 import { parseQueryParams, replaceQueryParam } from '~/util/queryParams';
 import { pluralize } from '~/util/strings';
 import tw from '~/util/tailwind';
@@ -17,7 +17,7 @@ import VersionBox from './VersionBox';
 const VERSIONS_TO_SHOW = 25;
 
 type Props = {
-  registryData: NpmRegistryData;
+  registryData: PackageVersionsData;
   npmDownloads?: NpmPerVersionDownloads;
 };
 

--- a/pages/package/[name]/[scopedName]/versions.tsx
+++ b/pages/package/[name]/[scopedName]/versions.tsx
@@ -5,6 +5,7 @@ import PackageVersionsScene from '~/scenes/PackageVersionsScene';
 import { type PackageVersionsPageProps } from '~/types/pages';
 import { EMPTY_PACKAGE_DATA, NEXT_10M_CACHE_HEADER } from '~/util/Constants';
 import { getPackagePageErrorProps } from '~/util/getPackagePageErrorProps';
+import { trimPackageVersionsData } from '~/util/packageVersionsRegistryData';
 import { parseQueryParams } from '~/util/queryParams';
 import { ssrFetch } from '~/util/SSRFetch';
 
@@ -51,11 +52,13 @@ export async function getServerSideProps(ctx: NextPageContext) {
       return getPackagePageErrorProps(packageName, apiResponse.status, npmResponse.status);
     }
 
+    const registryData = trimPackageVersionsData(await npmResponse.json());
+
     return {
       props: {
         packageName,
+        registryData,
         apiData: await apiResponse.json(),
-        registryData: await npmResponse.json(),
         npmDownloads: await npmDownloads.json(),
       },
     };

--- a/pages/package/[name]/versions.tsx
+++ b/pages/package/[name]/versions.tsx
@@ -5,6 +5,7 @@ import PackageVersionsScene from '~/scenes/PackageVersionsScene';
 import { type PackageVersionsPageProps } from '~/types/pages';
 import { EMPTY_PACKAGE_DATA, NEXT_10M_CACHE_HEADER } from '~/util/Constants';
 import { getPackagePageErrorProps } from '~/util/getPackagePageErrorProps';
+import { trimPackageVersionsData } from '~/util/packageVersionsRegistryData';
 import { parseQueryParams } from '~/util/queryParams';
 import { ssrFetch } from '~/util/SSRFetch';
 
@@ -48,11 +49,13 @@ export async function getServerSideProps(ctx: NextPageContext) {
       return getPackagePageErrorProps(packageName, apiResponse.status, npmResponse.status);
     }
 
+    const registryData = trimPackageVersionsData(await npmResponse.json());
+
     return {
       props: {
         packageName,
+        registryData,
         apiData: await apiResponse.json(),
-        registryData: await npmResponse.json(),
         npmDownloads: await npmDownloads.json(),
       },
     };

--- a/types/index.ts
+++ b/types/index.ts
@@ -311,6 +311,18 @@ export type NpmRegistryVersionData = NpmRegistryCommonData & {
   _nodeVersion?: string;
 };
 
+export type PackageVersionData = Pick<
+  NpmRegistryVersionData,
+  'name' | 'version' | '_npmUser' | 'dependencies'
+> & {
+  dist?: Pick<NpmRegistryVersionData['dist'], 'unpackedSize'>;
+};
+
+export type PackageVersionsData = Pick<NpmRegistryData, 'dist-tags'> & {
+  versions: Record<string, PackageVersionData>;
+  time: Record<string, string>;
+};
+
 export type NpmUser = {
   name: string;
   email?: string;

--- a/types/pages.ts
+++ b/types/pages.ts
@@ -2,8 +2,8 @@ import {
   type APIResponseType,
   type LibraryType,
   type NpmPerVersionDownloads,
-  type NpmRegistryData,
   type NpmRegistryVersionData,
+  type PackageVersionsData,
   type Query,
   type StatisticResultType,
 } from '~/types';
@@ -50,7 +50,7 @@ export type PackageVersionsPageProps = {
   apiData: {
     libraries: LibraryType[];
   };
-  registryData?: NpmRegistryData;
+  registryData?: PackageVersionsData;
   npmDownloads?: NpmPerVersionDownloads;
   errorMessage?: string;
 };

--- a/util/packageVersionsRegistryData.ts
+++ b/util/packageVersionsRegistryData.ts
@@ -1,0 +1,47 @@
+import { type NpmRegistryData, type PackageVersionData, type PackageVersionsData } from '~/types';
+
+export function trimPackageVersionsData(registryData: NpmRegistryData): PackageVersionsData {
+  const versions = Object.entries(registryData.versions).reduce<Record<string, PackageVersionData>>(
+    (acc, [versionKey, { name, version, dist, dependencies, _npmUser }]) => {
+      const versionData: PackageVersionData = {
+        name,
+        version,
+      };
+
+      if (dist.unpackedSize) {
+        versionData.dist = { unpackedSize: dist.unpackedSize };
+      }
+
+      if (dependencies) {
+        versionData.dependencies = dependencies;
+      }
+
+      if (_npmUser) {
+        versionData._npmUser = {
+          name: _npmUser.name,
+          ...(_npmUser.email && { email: _npmUser.email }),
+          ...(_npmUser.url && { url: _npmUser.url }),
+          ...(_npmUser.trustedPublisher && {
+            trustedPublisher: _npmUser.trustedPublisher,
+          }),
+        };
+      }
+
+      acc[versionKey] = versionData;
+
+      return acc;
+    },
+    {}
+  );
+
+  const time = Object.keys(versions).reduce<Record<string, string>>((acc, version) => {
+    acc[version] = registryData.time[version];
+    return acc;
+  }, {});
+
+  return {
+    'dist-tags': registryData['dist-tags'],
+    versions,
+    time,
+  };
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Spotted that some package version pages produce warnings in the deployment logs due to the JSON data size caused by amount of versions that package has.

<img width="2730" height="281" alt="Screenshot 2026-04-29 205115" src="https://github.com/user-attachments/assets/9cc30879-b5df-4580-88f3-ec8ad540757b" />
<br/>

To reduce the amount of data transferred between client and server I have added a trim helper which only retains the data used by the scene/components, and drops most of the unused content.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.
