### PR TITLE
add package version selector to the code browser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@expo/match-media": "^0.4.0",
         "@m2d/react-markdown": "^1.0.0",
         "@radix-ui/react-hover-card": "^1.1.15",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-native-picker/picker": "^2.11.4",
         "@sentry/react": "^10.50.0",
@@ -486,9 +487,15 @@
 
     "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
 
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
     "@radix-ui/react-hover-card": ["@radix-ui/react-hover-card@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg=="],
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA=="],
 
     "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
 
@@ -812,6 +819,8 @@
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
@@ -1018,6 +1027,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
@@ -1161,6 +1172,8 @@
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
 
@@ -1688,7 +1701,13 @@
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
     "react-shiki": ["react-shiki@0.9.3", "", { "dependencies": { "clsx": "^2.1.1", "dequal": "^2.0.3", "hast-util-to-jsx-runtime": "^2.3.6", "shiki": "^4.0.0", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@types/react": ">=16.8.0", "@types/react-dom": ">=16.8.0", "react": ">= 16.8.0", "react-dom": ">= 16.8.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F2Uju1/BeUTFQeS+3v3HM0Ry4p+8gcLC4ssObmXxwrzlwPJYq5RGAKcA1r5JBEnJCpEVKf9PajnwM+JMwZnzGg=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-use-measure": ["react-use-measure@2.1.7", "", { "peerDependencies": { "react": ">=16.13", "react-dom": ">=16.13" }, "optionalPeers": ["react-dom"] }, "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="],
 
@@ -1936,7 +1955,11 @@
 
     "url-loader": ["url-loader@4.1.1", "", { "dependencies": { "loader-utils": "^2.0.0", "mime-types": "^2.1.27", "schema-utils": "^3.0.0" }, "peerDependencies": { "file-loader": "*", "webpack": "^4.0.0 || ^5.0.0" }, "optionalPeers": ["file-loader"] }, "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA=="],
 
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
     "use-debounce": ["use-debounce@10.1.1", "", { "peerDependencies": { "react": "*" } }, "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 

--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -9,7 +9,6 @@ import {
   type StyleProp,
   StyleSheet,
   useWindowDimensions,
-  type ViewStyle,
 } from 'react-native';
 import { type Style } from 'twrnc';
 
@@ -148,16 +147,27 @@ export function A({
   );
 }
 
-type HoverEffectProps = PressableProps & { style?: StyleProp<ViewStyle> };
+type HoverEffectProps = PressableProps & {
+  style?: Style;
+  hoveredStyle?: Style;
+  pressedStyle?: Style;
+};
 
-export function HoverEffect({ children, style, onPress, ...rest }: HoverEffectProps) {
+export function HoverEffect({
+  children,
+  style,
+  hoveredStyle,
+  pressedStyle,
+  onPress,
+  ...rest
+}: HoverEffectProps) {
   return (
     <Pressable
       style={({ hovered, pressed }) => [
         { transition: 'opacity 0.33s' },
-        hovered && tw`opacity-75`,
-        pressed && tw`opacity-50`,
         style,
+        hovered && (hoveredStyle ?? tw`opacity-75`),
+        pressed && (pressedStyle ?? tw`opacity-50`),
       ]}
       accessible={false}
       focusable={false}

--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -9,6 +9,7 @@ import {
   type StyleProp,
   StyleSheet,
   useWindowDimensions,
+  type ViewStyle,
 } from 'react-native';
 import { type Style } from 'twrnc';
 
@@ -148,7 +149,7 @@ export function A({
 }
 
 type HoverEffectProps = PressableProps & {
-  style?: Style;
+  style?: StyleProp<ViewStyle>;
   hoveredStyle?: Style;
   pressedStyle?: Style;
 };

--- a/components/Package/CodeBrowser/CodeBrowserContent.tsx
+++ b/components/Package/CodeBrowser/CodeBrowserContent.tsx
@@ -34,6 +34,7 @@ type Props = {
   packageName: string;
   isBrowserMaximized: boolean;
   toggleMaximized: () => void;
+  selectedVersion: string;
   repoUrl: string;
   filePath: string;
   fileData?: UnpkgMeta['files'][number];
@@ -43,6 +44,7 @@ export default function CodeBrowserContent({
   packageName,
   isBrowserMaximized,
   toggleMaximized,
+  selectedVersion,
   repoUrl,
   filePath,
   fileData,
@@ -68,7 +70,7 @@ export default function CodeBrowserContent({
 
   const { data, isLoading } = useSWR<string>(
     !isPreviewDisabled && (!isImageFile || (isImageFile && rawPreview))
-      ? `/api/proxy/unpkg?name=${packageName}&path=${filePath.replaceAll('+', '%2B')}`
+      ? `/api/proxy/unpkg?name=${packageName}&version=${selectedVersion}&path=${filePath.replaceAll('+', '%2B')}`
       : undefined,
     (url: string) =>
       fetch(url).then(res => {

--- a/components/Package/CodeBrowser/PackageVersionSelector.tsx
+++ b/components/Package/CodeBrowser/PackageVersionSelector.tsx
@@ -46,6 +46,21 @@ export default function PackageVersionSelector({
     return (data?.versions ?? []).filter(v => v.includes(query));
   }, [data?.versions, debouncedSearch]);
 
+  const filteredDistTags = useMemo(() => {
+    if (!data?.['dist-tags']) {
+      return null;
+    }
+    const query = debouncedSearch.trim();
+    const entries = Object.entries(data['dist-tags']);
+    if (!query) {
+      return entries;
+    }
+    const filtered = entries.filter(
+      ([tag, version]) => tag.includes(query) || version.includes(query)
+    );
+    return filtered.length > 0 ? filtered : null;
+  }, [data, debouncedSearch]);
+
   function handleOpenChange(next: boolean) {
     setOpen(next);
     if (!next) {
@@ -103,10 +118,10 @@ export default function PackageVersionSelector({
               />
             </View>
             <ScrollView style={tw`max-h-76`} keyboardShouldPersistTaps="handled" id="dropdown-list">
-              {data?.['dist-tags'] && !debouncedSearch.trim() && (
+              {filteredDistTags && (
                 <>
                   <SelectorGroupHeader>Dist tags</SelectorGroupHeader>
-                  {Object.entries(data['dist-tags']).map(([tag, version]) => (
+                  {filteredDistTags.map(([tag, version]) => (
                     <SelectorItemHoverEffect key={tag}>
                       <View onPointerDown={() => handleSelect(tag)}>
                         <Label
@@ -120,14 +135,12 @@ export default function PackageVersionSelector({
                       </View>
                     </SelectorItemHoverEffect>
                   ))}
-                  <View style={tw`mt-1 border-b border-palette-gray2 dark:border-default`} />
+                  {filteredVersions.length > 0 && (
+                    <View style={tw`mt-1 border-b border-palette-gray2 dark:border-default`} />
+                  )}
                 </>
               )}
-              {filteredVersions.length === 0 ? (
-                <View style={tw`px-3 py-2`}>
-                  <Label style={tw`text-center font-thin text-secondary`}>No versions match</Label>
-                </View>
-              ) : (
+              {filteredVersions.length > 0 && (
                 <>
                   <SelectorGroupHeader>Versions</SelectorGroupHeader>
                   {filteredVersions.map(version => (
@@ -145,6 +158,11 @@ export default function PackageVersionSelector({
                     </SelectorItemHoverEffect>
                   ))}
                 </>
+              )}
+              {filteredVersions.length === 0 && !filteredDistTags && (
+                <View style={tw`px-3 py-2`}>
+                  <Label style={tw`text-center font-thin text-secondary`}>No versions match</Label>
+                </View>
               )}
             </ScrollView>
           </View>

--- a/components/Package/CodeBrowser/PackageVersionSelector.tsx
+++ b/components/Package/CodeBrowser/PackageVersionSelector.tsx
@@ -4,9 +4,11 @@ import { type ColorValue, ScrollView, TextInput, View } from 'react-native';
 import useSWR from 'swr';
 import { useDebounce } from 'use-debounce';
 
-import { Caption, Label } from '~/common/styleguide';
+import { Label } from '~/common/styleguide';
 import { ArrowIcon } from '~/components/Icons';
 import ThreeDotsLoader from '~/components/Package/ThreeDotsLoader';
+import SelectorGroupHeader from '~/components/Selector/SelectorGroupHeader';
+import SelectorItemHoverEffect from '~/components/Selector/SelectorItemHoverEffect';
 import { type PackageVersionsOnlyData } from '~/types';
 import { TimeRange } from '~/util/datetime';
 import tw from '~/util/tailwind';
@@ -70,7 +72,9 @@ export default function PackageVersionSelector({
             </View>
           ) : (
             <View style={tw`flex-row items-center justify-between gap-1.5`}>
-              <Label numberOfLines={1}>{selectedVersion}</Label>
+              <Label numberOfLines={1} style={tw`select-none text-[13px]`}>
+                {selectedVersion}
+              </Label>
               <ArrowIcon
                 style={[tw`h-3 w-4 shrink-0 text-icon`, open ? tw`rotate-270` : tw`rotate-90`]}
               />
@@ -78,7 +82,6 @@ export default function PackageVersionSelector({
           )}
         </View>
       </Popover.Trigger>
-
       <Popover.Portal>
         <Popover.Content align="end" sideOffset={6}>
           <View
@@ -92,47 +95,54 @@ export default function PackageVersionSelector({
                 style={tw`px-2.5 py-1.5 text-sm text-black outline-0 dark:text-white`}
                 autoCorrect={false}
                 autoCapitalize="none"
-                placeholderTextColor={tw`text-palette-gray4`.color as ColorValue}
+                placeholderTextColor={
+                  tw.prefixMatch('dark')
+                    ? (tw`text-palette-gray5`.color as ColorValue)
+                    : (tw`text-palette-gray3`.color as ColorValue)
+                }
               />
             </View>
-            <ScrollView style={tw`max-h-64`} keyboardShouldPersistTaps="handled" id="dropdown-list">
+            <ScrollView style={tw`max-h-76`} keyboardShouldPersistTaps="handled" id="dropdown-list">
               {data?.['dist-tags'] && !debouncedSearch.trim() && (
                 <>
-                  <View style={tw`px-3 pt-2`}>
-                    <Caption style={tw`text-[11px] font-thin uppercase text-secondary`}>
-                      Dist tags
-                    </Caption>
-                  </View>
+                  <SelectorGroupHeader>Dist tags</SelectorGroupHeader>
                   {Object.entries(data['dist-tags']).map(([tag, version]) => (
-                    <View
-                      key={tag}
-                      style={tw`cursor-pointer px-3 py-1.5`}
-                      onPointerDown={() => handleSelect(version)}>
-                      <Label>{tag}</Label>
-                      <Label style={tw`text-[11px] font-thin text-secondary`}>{version}</Label>
-                    </View>
+                    <SelectorItemHoverEffect key={tag}>
+                      <View onPointerDown={() => handleSelect(tag)}>
+                        <Label
+                          style={[
+                            tw`text-[inherit]`,
+                            selectedVersion === tag && tw`text-primary-darker dark:text-primary`,
+                          ]}>
+                          {tag}
+                        </Label>
+                        <Label style={tw`text-[10px] font-thin text-secondary`}>{version}</Label>
+                      </View>
+                    </SelectorItemHoverEffect>
                   ))}
-                  <View style={tw`my-1 border-b border-palette-gray2 dark:border-default`} />
+                  <View style={tw`mt-1 border-b border-palette-gray2 dark:border-default`} />
                 </>
               )}
               {filteredVersions.length === 0 ? (
                 <View style={tw`px-3 py-2`}>
-                  <Label style={tw`text-center text-secondary`}>No versions match</Label>
+                  <Label style={tw`text-center font-thin text-secondary`}>No versions match</Label>
                 </View>
               ) : (
                 <>
-                  <View style={tw`px-3 pt-1`}>
-                    <Caption style={tw`text-[11px] font-thin uppercase text-secondary`}>
-                      Versions
-                    </Caption>
-                  </View>
+                  <SelectorGroupHeader>Versions</SelectorGroupHeader>
                   {filteredVersions.map(version => (
-                    <View
-                      key={version}
-                      style={tw`cursor-pointer px-3 py-1.5`}
-                      onPointerDown={() => handleSelect(version)}>
-                      <Label>{version}</Label>
-                    </View>
+                    <SelectorItemHoverEffect key={version}>
+                      <View onPointerDown={() => handleSelect(version)}>
+                        <Label
+                          style={[
+                            tw`text-[inherit]`,
+                            selectedVersion === version &&
+                              tw`text-primary-darker dark:text-primary`,
+                          ]}>
+                          {version}
+                        </Label>
+                      </View>
+                    </SelectorItemHoverEffect>
                   ))}
                 </>
               )}

--- a/components/Package/CodeBrowser/PackageVersionSelector.tsx
+++ b/components/Package/CodeBrowser/PackageVersionSelector.tsx
@@ -1,0 +1,145 @@
+import * as Popover from '@radix-ui/react-popover';
+import { useMemo, useRef, useState } from 'react';
+import { type ColorValue, ScrollView, TextInput, View } from 'react-native';
+import useSWR from 'swr';
+import { useDebounce } from 'use-debounce';
+
+import { Caption, Label } from '~/common/styleguide';
+import { ArrowIcon } from '~/components/Icons';
+import ThreeDotsLoader from '~/components/Package/ThreeDotsLoader';
+import { type PackageVersionsOnlyData } from '~/types';
+import { TimeRange } from '~/util/datetime';
+import tw from '~/util/tailwind';
+
+type Props = {
+  packageName: string;
+  selectedVersion: string;
+  setVersion: (selectedVersion: string) => void;
+};
+
+export default function PackageVersionSelector({
+  packageName,
+  selectedVersion,
+  setVersion,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch] = useDebounce(search, 150);
+  const inputRef = useRef<TextInput>(null);
+
+  const { data, isLoading } = useSWR<PackageVersionsOnlyData>(
+    `/api/proxy/npm-registry-versions?name=${packageName}&versionsOnly=true`,
+    (url: string) => fetch(url).then(res => res.json()),
+    {
+      dedupingInterval: TimeRange.HOUR * 1000,
+      revalidateOnFocus: false,
+    }
+  );
+
+  const filteredVersions = useMemo(() => {
+    const query = debouncedSearch.trim();
+    if (!query) {
+      return data?.versions ?? [];
+    }
+    return (data?.versions ?? []).filter(v => v.includes(query));
+  }, [data?.versions, debouncedSearch]);
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) {
+      setSearch('');
+    } else {
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }
+
+  function handleSelect(version: string) {
+    setVersion(version);
+    setOpen(false);
+    setSearch('');
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+      <Popover.Trigger asChild>
+        <View
+          style={tw`min-h-8 w-[180px] cursor-pointer justify-center overflow-hidden rounded-lg border border-palette-gray2 bg-default px-2 dark:border-default dark:bg-dark`}>
+          {isLoading ? (
+            <View style={tw`scale-75 text-center`}>
+              <ThreeDotsLoader />
+            </View>
+          ) : (
+            <View style={tw`flex-row items-center justify-between gap-1.5`}>
+              <Label numberOfLines={1}>{selectedVersion}</Label>
+              <ArrowIcon
+                style={[tw`h-3 w-4 shrink-0 text-icon`, open ? tw`rotate-270` : tw`rotate-90`]}
+              />
+            </View>
+          )}
+        </View>
+      </Popover.Trigger>
+
+      <Popover.Portal>
+        <Popover.Content align="end" sideOffset={6}>
+          <View
+            style={tw`w-56 overflow-hidden rounded-lg border border-palette-gray2 bg-default shadow-lg dark:border-default`}>
+            <View style={tw`border-b border-palette-gray2 dark:border-default`}>
+              <TextInput
+                ref={inputRef}
+                value={search}
+                onChangeText={setSearch}
+                placeholder="Filter versions…"
+                style={tw`px-2.5 py-1.5 text-sm text-black outline-0 dark:text-white`}
+                autoCorrect={false}
+                autoCapitalize="none"
+                placeholderTextColor={tw`text-palette-gray4`.color as ColorValue}
+              />
+            </View>
+            <ScrollView style={tw`max-h-64`} keyboardShouldPersistTaps="handled" id="dropdown-list">
+              {data?.['dist-tags'] && !debouncedSearch.trim() && (
+                <>
+                  <View style={tw`px-3 pt-2`}>
+                    <Caption style={tw`text-[11px] font-thin uppercase text-secondary`}>
+                      Dist tags
+                    </Caption>
+                  </View>
+                  {Object.entries(data['dist-tags']).map(([tag, version]) => (
+                    <View
+                      key={tag}
+                      style={tw`cursor-pointer px-3 py-1.5`}
+                      onPointerDown={() => handleSelect(version)}>
+                      <Label>{tag}</Label>
+                      <Label style={tw`text-[11px] font-thin text-secondary`}>{version}</Label>
+                    </View>
+                  ))}
+                  <View style={tw`my-1 border-b border-palette-gray2 dark:border-default`} />
+                </>
+              )}
+              {filteredVersions.length === 0 ? (
+                <View style={tw`px-3 py-2`}>
+                  <Label style={tw`text-center text-secondary`}>No versions match</Label>
+                </View>
+              ) : (
+                <>
+                  <View style={tw`px-3 pt-1`}>
+                    <Caption style={tw`text-[11px] font-thin uppercase text-secondary`}>
+                      Versions
+                    </Caption>
+                  </View>
+                  {filteredVersions.map(version => (
+                    <View
+                      key={version}
+                      style={tw`cursor-pointer px-3 py-1.5`}
+                      onPointerDown={() => handleSelect(version)}>
+                      <Label>{version}</Label>
+                    </View>
+                  ))}
+                </>
+              )}
+            </ScrollView>
+          </View>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/components/Package/CodeBrowser/index.tsx
+++ b/components/Package/CodeBrowser/index.tsx
@@ -22,6 +22,7 @@ import CodeBrowserFileTree from './CodeBrowserFileTree';
 
 type Props = {
   library: LibraryType;
+  selectedVersion: string;
   activeFile: string | null;
   onSelectFile: (filePath: string | null) => void;
   isBrowserMaximized: boolean;
@@ -30,6 +31,7 @@ type Props = {
 
 export default function CodeBrowser({
   library,
+  selectedVersion,
   activeFile,
   onSelectFile,
   isBrowserMaximized,
@@ -42,7 +44,7 @@ export default function CodeBrowser({
   const [isInputFocused, setInputFocused] = useState(false);
 
   const { data, isLoading } = useSWR<UnpkgMeta>(
-    `/api/proxy/unpkg?name=${library.npmPkg}&path=?meta`,
+    `/api/proxy/unpkg?name=${library.npmPkg}&version=${selectedVersion}&path=?meta`,
     (url: string) => fetch(url).then(res => res.json()),
     {
       dedupingInterval: TimeRange.HOUR * 1000,
@@ -248,6 +250,7 @@ export default function CodeBrowser({
               <CodeBrowserContent
                 packageName={library.npmPkg}
                 repoUrl={library.github.urls.repo}
+                selectedVersion={selectedVersion}
                 filePath={activeFile}
                 fileData={activeFileData}
                 isBrowserMaximized={isBrowserMaximized}

--- a/components/Package/CodeBrowser/index.tsx
+++ b/components/Package/CodeBrowser/index.tsx
@@ -119,9 +119,9 @@ export default function CodeBrowser({
     [data?.files, data?.prefix, activeFile]
   );
 
-  const visibleFilePaths = useMemo(
-    () => new Set(filteredFiles.map(file => getCodeBrowserFilePath(file.path, data?.prefix))),
-    [filteredFiles, data?.prefix]
+  const allFilePaths = useMemo(
+    () => new Set((data?.files ?? []).map(file => getCodeBrowserFilePath(file.path, data?.prefix))),
+    [data?.files, data?.prefix]
   );
 
   useEffect(() => {
@@ -129,10 +129,10 @@ export default function CodeBrowser({
       return;
     }
 
-    if (activeFile && !visibleFilePaths.has(activeFile)) {
+    if (activeFile && !allFilePaths.has(activeFile)) {
       onSelectFile(null);
     }
-  }, [activeFile, data, onSelectFile, visibleFilePaths]);
+  }, [activeFile, allFilePaths, data, onSelectFile]);
 
   return (
     <View

--- a/components/Selector/SelectorGroupHeader.tsx
+++ b/components/Selector/SelectorGroupHeader.tsx
@@ -1,0 +1,15 @@
+import { type PropsWithChildren } from 'react';
+import { View } from 'react-native';
+
+import { Caption } from '~/common/styleguide';
+import tw from '~/util/tailwind';
+
+export default function SelectorGroupHeader({ children }: PropsWithChildren) {
+  return (
+    <View style={tw`px-3 pt-2`}>
+      <Caption style={tw`text-[11px] font-thin uppercase text-palette-gray4 dark:text-tertiary`}>
+        {children}
+      </Caption>
+    </View>
+  );
+}

--- a/components/Selector/SelectorItemHoverEffect.tsx
+++ b/components/Selector/SelectorItemHoverEffect.tsx
@@ -1,0 +1,14 @@
+import { type PropsWithChildren } from 'react';
+
+import { HoverEffect } from '~/common/styleguide';
+import tw from '~/util/tailwind';
+
+export default function SelectorItemHoverEffect({ children }: PropsWithChildren) {
+  return (
+    <HoverEffect
+      style={tw`cursor-pointer px-3 py-1.5 text-black dark:text-white`}
+      hoveredStyle={tw`bg-palette-gray2 dark:bg-palette-gray7`}>
+      {children}
+    </HoverEffect>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@expo/match-media": "^0.4.0",
     "@m2d/react-markdown": "^1.0.0",
     "@radix-ui/react-hover-card": "^1.1.15",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-native-picker/picker": "^2.11.4",
     "@sentry/react": "^10.50.0",

--- a/pages/api/proxy/npm-registry-versions.ts
+++ b/pages/api/proxy/npm-registry-versions.ts
@@ -1,0 +1,46 @@
+import { type NextApiRequest, type NextApiResponse } from 'next';
+
+import { NEXT_10M_CACHE_HEADER } from '~/util/Constants';
+import { trimPackageVersionsData } from '~/util/packageVersionsRegistryData';
+import { parseQueryParams } from '~/util/queryParams';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  console.warn(req.query);
+  const { name, versionsOnly } = parseQueryParams(req.query);
+  const packageName = name ? name.toString().toLowerCase().trim() : undefined;
+  const versionsOnlyFlag = versionsOnly
+    ? Boolean(versionsOnly.toString().toLowerCase().trim())
+    : false;
+
+  res.setHeader('Content-Type', 'application/json');
+
+  if (!packageName) {
+    res.statusCode = 500;
+    res.json({
+      error: `Invalid request. You need to specify package name via 'name' query param.`,
+    });
+    return;
+  }
+
+  const result = await fetch(`https://registry.npmjs.org/${packageName}`, NEXT_10M_CACHE_HEADER);
+
+  if ('status' in result && result.status !== 200) {
+    res.statusCode = result.status;
+    res.json({});
+    return;
+  }
+
+  const versionsData = await result.json();
+
+  res.statusCode = 200;
+  res.setHeader('Cache-Control', 'public, s-maxage=600, stale-while-revalidate=300');
+
+  if (versionsOnlyFlag) {
+    res.json({
+      'dist-tags': versionsData['dist-tags'],
+      versions: Object.keys(versionsData.versions).reverse(),
+    });
+  } else {
+    res.json(trimPackageVersionsData(versionsData));
+  }
+}

--- a/pages/api/proxy/unpkg.ts
+++ b/pages/api/proxy/unpkg.ts
@@ -6,9 +6,10 @@ import { parseQueryParams } from '~/util/queryParams';
 const UNPKG_TIMEOUT_MS = 15_000;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { name, path } = parseQueryParams(req.query);
+  const { name, version, path } = parseQueryParams(req.query);
 
   const packageName = name ? name.toString().toLowerCase().trim() : undefined;
+  const packageVersion = version ? version.toString().toLowerCase().trim() : 'latest';
   const apiPath = path ? path.toString().trim() : undefined;
 
   res.setHeader('Cache-Control', 'public, s-maxage=600, stale-while-revalidate=300');
@@ -23,7 +24,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const result = await fetch(`https://unpkg.com/${packageName}/${apiPath}`, {
+    const result = await fetch(`https://unpkg.com/${packageName}@${packageVersion}/${apiPath}`, {
       ...NEXT_10M_CACHE_HEADER,
       redirect: 'manual',
       signal: AbortSignal.timeout(UNPKG_TIMEOUT_MS),
@@ -67,7 +68,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     res.setHeader('Content-Type', 'application/json');
     res.statusCode = 200;
-    res.json(await result.json());
+    res.write(await result.text());
+    res.end();
   } catch (error) {
     if (error instanceof Error && error.name !== 'AbortError' && error.name !== 'TimeoutError') {
       throw error;

--- a/pages/package/[name]/[scopedName]/versions.tsx
+++ b/pages/package/[name]/[scopedName]/versions.tsx
@@ -4,10 +4,12 @@ import ErrorScene from '~/scenes/ErrorScene';
 import PackageVersionsScene from '~/scenes/PackageVersionsScene';
 import { type PackageVersionsPageProps } from '~/types/pages';
 import { EMPTY_PACKAGE_DATA, NEXT_10M_CACHE_HEADER } from '~/util/Constants';
+import getApiUrl from '~/util/getApiUrl';
 import { getPackagePageErrorProps } from '~/util/getPackagePageErrorProps';
 import { trimPackageVersionsData } from '~/util/packageVersionsRegistryData';
 import { parseQueryParams } from '~/util/queryParams';
 import { ssrFetch } from '~/util/SSRFetch';
+import urlWithQuery from '~/util/urlWithQuery';
 
 export default function ScopedVersionsPage({
   apiData,
@@ -41,7 +43,10 @@ export async function getServerSideProps(ctx: NextPageContext) {
   try {
     const [apiResponse, npmResponse, npmDownloads] = await Promise.all([
       ssrFetch(`/libraries`, { search: packageName }, ctx),
-      fetch(`https://registry.npmjs.org/${packageName}`, NEXT_10M_CACHE_HEADER),
+      fetch(
+        getApiUrl(urlWithQuery(`/proxy/npm-registry-versions/?name=${packageName}`), ctx),
+        NEXT_10M_CACHE_HEADER
+      ),
       fetch(
         `https://api.npmjs.org/versions/${[queryParams.name, queryParams.scopedName].join('%2F')}/last-week`,
         NEXT_10M_CACHE_HEADER

--- a/pages/package/[name]/versions.tsx
+++ b/pages/package/[name]/versions.tsx
@@ -4,10 +4,12 @@ import ErrorScene from '~/scenes/ErrorScene';
 import PackageVersionsScene from '~/scenes/PackageVersionsScene';
 import { type PackageVersionsPageProps } from '~/types/pages';
 import { EMPTY_PACKAGE_DATA, NEXT_10M_CACHE_HEADER } from '~/util/Constants';
+import getApiUrl from '~/util/getApiUrl';
 import { getPackagePageErrorProps } from '~/util/getPackagePageErrorProps';
 import { trimPackageVersionsData } from '~/util/packageVersionsRegistryData';
 import { parseQueryParams } from '~/util/queryParams';
 import { ssrFetch } from '~/util/SSRFetch';
+import urlWithQuery from '~/util/urlWithQuery';
 
 export default function VersionsPage({
   apiData,
@@ -41,7 +43,10 @@ export async function getServerSideProps(ctx: NextPageContext) {
   try {
     const [apiResponse, npmResponse, npmDownloads] = await Promise.all([
       ssrFetch(`/libraries`, { search: packageName }, ctx),
-      fetch(`https://registry.npmjs.org/${packageName}`, NEXT_10M_CACHE_HEADER),
+      fetch(
+        getApiUrl(urlWithQuery(`/proxy/npm-registry-versions/?name=${packageName}`), ctx),
+        NEXT_10M_CACHE_HEADER
+      ),
       fetch(`https://api.npmjs.org/versions/${packageName}/last-week`, NEXT_10M_CACHE_HEADER),
     ]);
 

--- a/scenes/PackageCodeScene.tsx
+++ b/scenes/PackageCodeScene.tsx
@@ -84,8 +84,6 @@ export default function PackageCodeScene({ apiData, packageName }: PackageCodePa
     };
   }, [activeFileStorageKey, router.events]);
 
-  const browserPortalTarget = typeof document === 'undefined' ? null : document.body;
-
   if (!library) {
     return <NotFound />;
   }
@@ -124,8 +122,8 @@ export default function PackageCodeScene({ apiData, packageName }: PackageCodePa
               />
             </View>
           </View>
-          {isBrowserMaximized && browserPortalTarget
-            ? createPortal(codeBrowser, browserPortalTarget)
+          {isBrowserMaximized && document.body
+            ? createPortal(codeBrowser, document.body)
             : codeBrowser}
         </View>
       </ContentContainer>

--- a/scenes/PackageCodeScene.tsx
+++ b/scenes/PackageCodeScene.tsx
@@ -3,8 +3,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { View } from 'react-native';
 
+import { Label } from '~/common/styleguide';
 import ContentContainer from '~/components/ContentContainer';
 import CodeBrowser from '~/components/Package/CodeBrowser';
+import PackageVersionSelector from '~/components/Package/CodeBrowser/PackageVersionSelector';
 import DetailsNavigation from '~/components/Package/DetailsNavigation';
 import NotFound from '~/components/Package/NotFound';
 import PackageHeader from '~/components/Package/PackageHeader';
@@ -18,6 +20,7 @@ export default function PackageCodeScene({ apiData, packageName }: PackageCodePa
   const router = useRouter();
   const activeFileStorageKey = `${ACTIVE_FILE_STORAGE_KEY_PREFIX}:${packageName}`;
 
+  const [selectedVersion, setSelectedVersion] = useState('latest');
   const [activeFile, setActiveFile] = useState<string | null>(() =>
     window.localStorage.getItem(activeFileStorageKey)
   );
@@ -89,6 +92,7 @@ export default function PackageCodeScene({ apiData, packageName }: PackageCodePa
 
   const codeBrowser = (
     <CodeBrowser
+      selectedVersion={selectedVersion}
       library={library}
       activeFile={activeFile}
       onSelectFile={setActiveFile}
@@ -106,8 +110,20 @@ export default function PackageCodeScene({ apiData, packageName }: PackageCodePa
       />
       <DetailsNavigation library={library} />
       <ContentContainer style={tw`my-6 px-5 pb-3`}>
-        <View style={tw`relative flex-1 gap-3`}>
-          <PackageHeader library={library} skipDescription />
+        <View style={tw`flex-1 gap-3`}>
+          <View style={tw`flex flex-row items-center justify-between`}>
+            <View style={tw`gap-3`}>
+              <PackageHeader library={library} skipDescription />
+            </View>
+            <View style={tw`gap-1`}>
+              <Label style={tw`px-1.5 text-secondary`}>Package version</Label>
+              <PackageVersionSelector
+                packageName={library.npmPkg}
+                selectedVersion={selectedVersion}
+                setVersion={selectedVersion => setSelectedVersion(selectedVersion)}
+              />
+            </View>
+          </View>
           {isBrowserMaximized && browserPortalTarget
             ? createPortal(codeBrowser, browserPortalTarget)
             : codeBrowser}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -785,6 +785,13 @@ select {
   }
 }
 
+/* PACKAGE VERSIONS DROPDOWN */
+
+#dropdown-list {
+  scrollbar-color: var(--icon) var(--background);
+  scrollbar-gutter: stable;
+}
+
 /* CODE BROWSER */
 
 #codeBrowser {

--- a/types/index.ts
+++ b/types/index.ts
@@ -323,6 +323,10 @@ export type PackageVersionsData = Pick<NpmRegistryData, 'dist-tags'> & {
   time: Record<string, string>;
 };
 
+export type PackageVersionsOnlyData = Pick<NpmRegistryData, 'dist-tags'> & {
+  versions: string[];
+};
+
 export type NpmUser = {
   name: string;
   email?: string;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

It might be handy for some to see other than latest versions code or compare given file changes in the bundle in time.

This PR adds the package version selector to the code browser, moves npm version data fetch to a proxy API and fixes few small issues.

> [!note]
> Pushing as a draft for now, since there are some small things to address, including a11y, and the feature needs a bit more of testing.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

<img width="1831" height="715" alt="Screenshot 2026-04-30 223713" src="https://github.com/user-attachments/assets/a46e3ee9-0c3b-4151-80f3-9c8aca469e82" />
