### PR TITLE
Add react-native-twitter-preview

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20802,5 +20802,11 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/idanlevi1/react-native-twitter-preview",
+    "npmPkg": "react-native-twitter-preview",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
## Add react-native-twitter-preview

Embed Twitter/X tweet previews in React Native using just a tweet URL. Renders author, text, and media with customizable styling.

- **iOS & Android**
- **Lightweight** — single dependency (react-native-webview)
- npm: [react-native-twitter-preview](https://www.npmjs.com/package/react-native-twitter-preview)
- GitHub: [idanlevi1/react-native-twitter-preview](https://github.com/idanlevi1/react-native-twitter-preview)