### PR TITLE
Add react-native-record-screen-extended

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20808,5 +20808,11 @@
     "npmPkg": "react-native-twitter-preview",
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/idanlevi1/react-native-record-screen-extended",
+    "npmPkg": "react-native-record-screen-extended",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
## Add react-native-record-screen-extended

Screen recording for React Native with Android 14+ MediaProjectionConfig support. Adds `startRecordingEntireScreen()` to block the "Single app" recording option.

- **iOS & Android**
- **Drop-in replacement** for react-native-record-screen
- npm: [react-native-record-screen-extended](https://www.npmjs.com/package/react-native-record-screen-extended)
- GitHub: [idanlevi1/react-native-record-screen-extended](https://github.com/idanlevi1/react-native-record-screen-extended)