### PR TITLE
Add @qvac/sdk – Local AI (LLM, STT, TTS) SDK with Expo support

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20808,5 +20808,13 @@
     "npmPkg": "react-native-twitter-preview",
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/tetherto/qvac",
+    "npmPkg": "@qvac/sdk",
+    "ios": true,
+    "android": true,
+    "windows": true,
+    "macos": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20810,17 +20810,15 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/tetherto/qvac",
-    "npmPkg": "@qvac/sdk",
-    "ios": true,
-    "android": true,
-    "windows": true,
-    "macos": true
-  },
-  {
     "githubUrl": "https://github.com/idanlevi1/react-native-record-screen-extended",
     "npmPkg": "react-native-record-screen-extended",
     "ios": true,
     "android": true
-  }
+  },
+  {
+    "githubUrl": "https://github.com/tetherto/qvac/tree/main/packages/sdk",
+    "npmPkg": "@qvac/sdk",
+    "ios": true,
+    "android": true
+  },
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20820,5 +20820,5 @@
     "npmPkg": "@qvac/sdk",
     "ios": true,
     "android": true
-  },
+  }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `@qvac/sdk` to `react-native-libraries.json`.

**@qvac/sdk** is a local-first AI SDK by Tether that enables running AI models (LLMs, speech-to-text, text-to-speech, translation, RAG, and more) directly on-device — without any cloud dependency, API keys, or internet connection.

It supports **Expo** (React Native) natively via its `@qvac/sdk/expo-plugin` and runs on both **Android and iOS** physical devices.

Key highlights:
- 🔒 **Private by default** – inference runs fully on-device
- 📱 **Expo-compatible** – includes an Expo config plugin out of the box
- 🌐 **P2P capable** – can delegate inference to peers via Holepunch stack
- 🔤 **TypeScript** – fully typed JS API
- ⚖️ **Apache 2.0** – free for commercial use
- 🔗 npm: https://www.npmjs.com/package/@qvac/sdk
- 🔗 GitHub: https://github.com/tetherto/qvac

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
- [x] Resolves issue #2427