### PR TITLE
fix contradictory ARIA on Button

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -48,7 +48,7 @@ export function Button({
           </View>
         </A>
       ) : (
-        <View role="button" focusable={false} style={buttonStyle} accessible={false} {...rest}>
+        <View role="button" focusable={false} style={buttonStyle} {...rest}>
           {content}
         </View>
       )}


### PR DESCRIPTION
## Summary

The non-link `Button` variant in `components/Button.tsx` set `role=\"button\"` together with `accessible={false}` on the same `View`. These cancel out: `accessible={false}` hides the element from assistive technology, so the explicit `role=\"button\"` never reaches screen readers.

This drops `accessible={false}` from that `View` so the role is actually announced. The link variant is unchanged — there the inner `View` is correctly hidden because the wrapping `<A>` is the accessible element.