### PR TITLE
add rel="noopener noreferrer" to external links

### DIFF
--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -140,7 +140,11 @@ export function A({
         href={href}
         numberOfLines={containerStyle ? 1 : undefined}
         target={target ?? '_blank'}
-        hrefAttrs={{ target: target ?? '_blank' }}
+        rel={(target ?? '_blank') === '_blank' ? 'noopener noreferrer' : undefined}
+        hrefAttrs={{
+          target: target ?? '_blank',
+          ...((target ?? '_blank') === '_blank' ? { rel: 'noopener noreferrer' } : {}),
+        }}
         style={[linkStyles, isHovered && linkHoverStyles, style, isHovered && hoverStyle]}>
         {children}
       </HtmlElements.A>


### PR DESCRIPTION
## Summary

The shared `<A>` component in `common/styleguide.tsx` defaults `target` to `_blank` but does not emit a matching `rel` attribute. Links opened in a new tab without `rel="noopener"` allow the new page to access `window.opener`, which is a known tabnabbing vector, and without `noreferrer` the referrer is leaked to the destination.

This sets `rel="noopener noreferrer"` (on both the web `rel` prop and the React Native `hrefAttrs`) whenever the resolved target is `_blank`. Internal `target="_self"` links are unaffected.