### PR TITLE
set descriptive alt text on library screenshot thumbnails

### DIFF
--- a/components/Library/Thumbnail.tsx
+++ b/components/Library/Thumbnail.tsx
@@ -7,11 +7,12 @@ import tw from '~/util/tailwind';
 
 type Props = {
   url: string;
+  name: string;
 };
 
 const GITHUB_PREVIEW_MIN_WIDTH = 640;
 
-function Thumbnail({ url }: Props) {
+function Thumbnail({ url, name }: Props) {
   const { width, height } = useWindowDimensions();
 
   const [isLoaded, setLoaded] = useState(false);
@@ -56,7 +57,7 @@ function Thumbnail({ url }: Props) {
             <img
               src={url}
               onLoad={() => setLoaded(true)}
-              alt=""
+              alt={`${name} screenshot`}
               style={{
                 ...tw`rounded`,
                 maxWidth: maxPreviewImageWidth,

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -126,7 +126,7 @@ export default function Library({
         {!skipMetadata && Platform.OS === 'web' && library.images && library.images.length > 0 && (
           <View style={tw`mt-2 flex-row flex-wrap items-center gap-x-0.5`}>
             {library.images.map(image => (
-              <Thumbnail key={image} url={image} />
+              <Thumbnail key={image} url={image} name={libName} />
             ))}
           </View>
         )}


### PR DESCRIPTION
## Summary

`components/Library/Thumbnail.tsx` rendered the screenshot `<img>` with `alt=""`, which signals to assistive technology that the image is purely decorative. These are actual package screenshots, so the empty alt hides meaningful content from screen readers.

This threads the library name (`npmPkg ?? github.fullName`) from `Library/index.tsx` into `Thumbnail` and uses it as the alt text (e.g. `"react-native-foo screenshot"`).