### PR TITLE
Add react-native-nitro-notification to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20820,5 +20820,15 @@
     "npmPkg": "@qvac/sdk",
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/Pnlvfx/react-native-nitro-notification",
+    "examples": [""],
+    "images": [""],
+    "newArchitecture": true,
+    "ios": true,
+    "macos": true,
+    "tvos": true,
+    "visionos": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `react-native-nitro-notification` (https://github.com/Pnlvfx/react-native-nitro-notification) package to the directory.

> [!NOTE]
> This is an automatic submission created via `rn-directory` CLI.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
