### PR TITLE
fix version data trim helper, a11y tweaks for version selector

### DIFF
--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -160,19 +160,21 @@ export function HoverEffect({
   hoveredStyle,
   pressedStyle,
   onPress,
+  focusable = false,
   ...rest
 }: HoverEffectProps) {
   return (
     <Pressable
       style={({ hovered, pressed }) => [
+        tw`-outline-offset-2`,
         { transition: 'opacity 0.33s' },
         style,
         hovered && (hoveredStyle ?? tw`opacity-75`),
         pressed && (pressedStyle ?? tw`opacity-50`),
       ]}
-      accessible={false}
-      focusable={false}
-      tabIndex={onPress ? 0 : -1}
+      accessible={focusable}
+      focusable={focusable}
+      tabIndex={onPress || focusable ? 0 : -1}
       onPress={onPress}
       {...rest}>
       {children}

--- a/components/Package/CodeBrowser/PackageVersionSelector.tsx
+++ b/components/Package/CodeBrowser/PackageVersionSelector.tsx
@@ -80,6 +80,7 @@ export default function PackageVersionSelector({
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
       <Popover.Trigger asChild>
         <View
+          role="button"
           style={tw`min-h-8 w-[180px] cursor-pointer justify-center overflow-hidden rounded-lg border border-palette-gray2 bg-default px-2 dark:border-default dark:bg-dark`}>
           {isLoading ? (
             <View style={tw`scale-75 text-center`}>
@@ -117,22 +118,24 @@ export default function PackageVersionSelector({
                 }
               />
             </View>
-            <ScrollView style={tw`max-h-76`} keyboardShouldPersistTaps="handled" id="dropdown-list">
+            <ScrollView
+              style={tw`max-h-76`}
+              focusable={false}
+              keyboardShouldPersistTaps="handled"
+              id="dropdown-list">
               {filteredDistTags && (
                 <>
                   <SelectorGroupHeader>Dist tags</SelectorGroupHeader>
                   {filteredDistTags.map(([tag, version]) => (
-                    <SelectorItemHoverEffect key={tag}>
-                      <View onPointerDown={() => handleSelect(tag)}>
-                        <Label
-                          style={[
-                            tw`text-[inherit]`,
-                            selectedVersion === tag && tw`text-primary-darker dark:text-primary`,
-                          ]}>
-                          {tag}
-                        </Label>
-                        <Label style={tw`text-[10px] font-thin text-secondary`}>{version}</Label>
-                      </View>
+                    <SelectorItemHoverEffect key={tag} onPressIn={() => handleSelect(tag)}>
+                      <Label
+                        style={[
+                          tw`text-[inherit]`,
+                          selectedVersion === tag && tw`text-primary-darker dark:text-primary`,
+                        ]}>
+                        {tag}
+                      </Label>
+                      <Label style={tw`text-[10px] font-thin text-secondary`}>{version}</Label>
                     </SelectorItemHoverEffect>
                   ))}
                   {filteredVersions.length > 0 && (
@@ -144,17 +147,14 @@ export default function PackageVersionSelector({
                 <>
                   <SelectorGroupHeader>Versions</SelectorGroupHeader>
                   {filteredVersions.map(version => (
-                    <SelectorItemHoverEffect key={version}>
-                      <View onPointerDown={() => handleSelect(version)}>
-                        <Label
-                          style={[
-                            tw`text-[inherit]`,
-                            selectedVersion === version &&
-                              tw`text-primary-darker dark:text-primary`,
-                          ]}>
-                          {version}
-                        </Label>
-                      </View>
+                    <SelectorItemHoverEffect key={version} onPressIn={() => handleSelect(version)}>
+                      <Label
+                        style={[
+                          tw`text-[inherit]`,
+                          selectedVersion === version && tw`text-primary-darker dark:text-primary`,
+                        ]}>
+                        {version}
+                      </Label>
                     </SelectorItemHoverEffect>
                   ))}
                 </>

--- a/components/Selector/SelectorItemHoverEffect.tsx
+++ b/components/Selector/SelectorItemHoverEffect.tsx
@@ -1,13 +1,15 @@
-import { type PropsWithChildren } from 'react';
+import { type PressableProps } from 'react-native';
 
 import { HoverEffect } from '~/common/styleguide';
 import tw from '~/util/tailwind';
 
-export default function SelectorItemHoverEffect({ children }: PropsWithChildren) {
+export default function SelectorItemHoverEffect({ children, ...rest }: PressableProps) {
   return (
     <HoverEffect
       style={tw`cursor-pointer px-3 py-1.5 text-black dark:text-white`}
-      hoveredStyle={tw`bg-palette-gray2 dark:bg-palette-gray7`}>
+      hoveredStyle={tw`bg-palette-gray2 dark:bg-palette-gray7`}
+      focusable
+      {...rest}>
       {children}
     </HoverEffect>
   );

--- a/pages/api/proxy/npm-registry-versions.ts
+++ b/pages/api/proxy/npm-registry-versions.ts
@@ -5,7 +5,6 @@ import { trimPackageVersionsData } from '~/util/packageVersionsRegistryData';
 import { parseQueryParams } from '~/util/queryParams';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.warn(req.query);
   const { name, versionsOnly } = parseQueryParams(req.query);
   const packageName = name ? name.toString().toLowerCase().trim() : undefined;
   const versionsOnlyFlag = versionsOnly

--- a/pages/package/[name]/[scopedName]/versions.tsx
+++ b/pages/package/[name]/[scopedName]/versions.tsx
@@ -67,7 +67,8 @@ export async function getServerSideProps(ctx: NextPageContext) {
         npmDownloads: await npmDownloads.json(),
       },
     };
-  } catch {
+  } catch (error) {
+    console.error(error);
     return EMPTY_PACKAGE_DATA;
   }
 }

--- a/pages/package/[name]/versions.tsx
+++ b/pages/package/[name]/versions.tsx
@@ -64,7 +64,8 @@ export async function getServerSideProps(ctx: NextPageContext) {
         npmDownloads: await npmDownloads.json(),
       },
     };
-  } catch {
+  } catch (error) {
+    console.error(error);
     return EMPTY_PACKAGE_DATA;
   }
 }

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20423,7 +20423,6 @@
   },
   {
     "githubUrl": "https://github.com/DimaIvashchuk/react-native-background-workers",
-    "npmPkg": "react-native-background-workers",
     "examples": [
       "https://github.com/DimaIvashchuk/react-native-background-workers/tree/main/example"
     ],
@@ -20798,20 +20797,17 @@
   },
   {
     "githubUrl": "https://github.com/idanlevi1/react-native-pick-contact",
-    "npmPkg": "react-native-pick-contact",
     "ios": true,
     "android": true,
     "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/idanlevi1/react-native-twitter-preview",
-    "npmPkg": "react-native-twitter-preview",
     "ios": true,
     "android": true
   },
   {
     "githubUrl": "https://github.com/idanlevi1/react-native-record-screen-extended",
-    "npmPkg": "react-native-record-screen-extended",
     "ios": true,
     "android": true
   },

--- a/util/packageVersionsRegistryData.ts
+++ b/util/packageVersionsRegistryData.ts
@@ -8,7 +8,7 @@ export function trimPackageVersionsData(registryData: NpmRegistryData): PackageV
         version,
       };
 
-      if (dist.unpackedSize) {
+      if (dist?.unpackedSize) {
         versionData.dist = { unpackedSize: dist.unpackedSize };
       }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Spotted that for some package version page fails to load data and returns 500 response. The root cause seems to be not always present `unpackedSize` field.

Also, withing this PR I have improved a11y of recently added version selector, allowing keyboard access and selection. I have also run `libraries:cleanup` script to trim out the libraries data.


# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
