### PR TITLE
Add react-native-nitro-geolocation

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20888,5 +20888,18 @@
       "https://raw.githubusercontent.com/manikagnish/expo-ui-swipe-actions/main/assets/swipe-actions.gif"
     ],
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/packages/react-native-nitro-geolocation",
+    "npmPkg": "react-native-nitro-geolocation",
+    "examples": [
+      "https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/examples/v0.81.1"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/demo.gif"
+    ],
+    "newArchitecture": "new-arch-only",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Add `react-native-nitro-geolocation` to React Native Directory.

This package is a Nitro Modules based geolocation library for React Native. It can be used as a New Architecture replacement for `@react-native-community/geolocation` through its `/compat` API, while also providing a modern functional API and additional capabilities such as location settings requests, availability checks, cached location access, geocoding, reverse geocoding, accuracy authorization helpers, heading support, and a DevTools plugin.

The entry points to the package subdirectory in the monorepo, marks iOS and Android support, sets New Architecture support to `new-arch-only`, and includes the example app plus demo GIF.

Validated locally with:

- `bun data:validate`
- `CI_CHECKS_TOKEN=$(gh auth token) GITHUB_TOKEN=$(gh auth token) bun ci:validate`
- `bun oxfmt react-native-libraries.json --check`
- `npm view react-native-nitro-geolocation name version --json`

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**