### PR TITLE
Add New Architecture support for react-native-stallion

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14871,15 +14871,8 @@
     "ios": true,
     "android": true,
     "newArchitecture": true,
-    "npmPkg": "react-native-stallion"
-  },
-  {
-    "githubUrl": "https://github.com/stallion-tech/expo-stallion-plugin",
-    "ios": true,
-    "android": true,
-    "newArchitecture": true,
-    "npmPkg": "expo-stallion-plugin",
-    "configPlugin": true,
+    "npmPkg": "react-native-stallion",
+    "configPlugin": "https://github.com/stallion-tech/expo-stallion-plugin",
     "expoGo": true
   },
   {

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14874,6 +14874,15 @@
     "npmPkg": "react-native-stallion"
   },
   {
+    "githubUrl": "https://github.com/stallion-tech/expo-stallion-plugin",
+    "ios": true,
+    "android": true,
+    "newArchitecture": true,
+    "npmPkg": "expo-stallion-plugin",
+    "configPlugin": true,
+    "expoGo": true
+  },
+  {
     "githubUrl": "https://github.com/razorRun/react-native-vlc-media-player",
     "examples": ["https://github.com/razorRun/react-native-vlc-media-player-test"],
     "ios": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14869,7 +14869,10 @@
     "githubUrl": "https://github.com/stallion-tech/react-native-stallion",
     "examples": ["https://github.com/stallion-tech/react-native-stallion/tree/main/example"],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture": true,
+    "configPlugin": true,
+    "expoGo": true
   },
   {
     "githubUrl": "https://github.com/razorRun/react-native-vlc-media-player",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20905,5 +20905,13 @@
     "newArchitecture": "new-arch-only",
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/stallion-tech/stallion-cli",
+    "npmPkg": "stallion-cli",
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "dev": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14871,8 +14871,7 @@
     "ios": true,
     "android": true,
     "newArchitecture": true,
-    "configPlugin": true,
-    "expoGo": true
+    "npmPkg": "react-native-stallion"
   },
   {
     "githubUrl": "https://github.com/razorRun/react-native-vlc-media-player",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Why: The react-native-stallion entry needed to surface its companion Expo config plugin and Expo Go compatibility so users discovering it through the directory know it works in Expo-managed projects without ejecting. stallion-cli is the developer tooling that pairs with react-native-stallion — it handles bundle uploads, release management, and OTA workflows. Adding it to the directory makes the full Stallion toolchain discoverable in one place

How: Updated the existing react-native-stallion entry in react-native-libraries.json:
  - Added configPlugin set to the expo-stallion-plugin GitHub URL (https://github.com/stallion-tech/expo-stallion-plugin)
  - Added expoGo: true to indicate Expo Go support
  - newArchitecture: true: Compatible with React Native's New Architecture (Fabric/TurboModules)
  - Appended a new entry at the end of      
  react-native-libraries.json:
  - githubUrl:                                 
  https://github.com/stallion-tech/stallion-cli
  - npmPkg: stallion-cli for npm install       
  resolution

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [x] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [x] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
