### PR TITLE
Add expo-reverse-tcp

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -20952,5 +20952,12 @@
     "android": true,
     "web": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/thejoaov/expo-android-tcp/tree/main/packages/android-reverse-tcp",
+    "npmPkg": "expo-reverse-tcp",
+    "examples": ["https://github.com/thejoaov/expo-android-tcp/tree/main/app/app"],
+    "android": true,
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `expo-reverse-tcp` (`thejoaov/expo-android-tcp`) package to the directory.

# ✅ Checklist

- [x] Added library to `react-native-libraries.json`
