### PR TITLE
Add expo-running-kit

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21004,5 +21004,12 @@
     "ios": true,
     "android": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/aliresana/expo-running-kit",
+    "npmPkg": "expo-running-kit",
+    "examples": ["https://github.com/aliresana/expo-running-kit/tree/main/example"],
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
## Description

Adds `expo-running-kit` — an Expo native module for tracking running and walking workouts.

**Features:**
- GPS tracking (distance, speed, pace) via CoreLocation / Fused Location Provider
- Step counting and cadence via CMPedometer / TYPE_STEP_COUNTER
- Auto-pause / auto-resume based on motion sensor (cadence)
- Lap recording
- GPS quality indicator
- Metric and imperial units

**Links:**
- npm: https://www.npmjs.com/package/expo-running-kit
- GitHub: https://github.com/aliresana/expo-running-kit