### PR TITLE
Add react-native-text-search

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21026,5 +21026,10 @@
     "android": true,
     "web": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/Talha-Yousaf/react-native-text-search",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
# Why & how

Adds `react-native-text-search` to the React Native Directory.

The library supports both iOS and Android.

# Checklist

- [x] Added library to **`react-native-libraries.json`**
