### PR TITLE
Mark react-native-markdown-display as unmaintained

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3907,7 +3907,9 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "fireos": true
+    "fireos": true,
+    "unmaintained": true,
+    "alternatives": ["react-native-enriched-markdown"]
   },
   {
     "githubUrl": "https://github.com/i18next/react-i18next",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3908,8 +3908,7 @@
     "android": true,
     "expoGo": true,
     "fireos": true,
-    "unmaintained": true,
-    "alternatives": ["react-native-enriched-markdown"]
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/i18next/react-i18next",


### PR DESCRIPTION
## 📝 Why & how

The [react-native-markdown-display GitHub repository](https://github.com/iamacup/react-native-markdown-display) already states that the project is no longer maintained. This PR marks it as `unmaintained` in the directory.

<img width="927" height="292" alt="Screenshot 2026-05-15 at 13 57 15" src="https://github.com/user-attachments/assets/b0ff30a0-5bed-4323-9e31-20e1e321c66a" />

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [ ] Documented how you found or replicated the issue.
- [ ] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
