### PR TITLE
Add react-native-enriched-markdown as alternative to react-native-markdown-display

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3908,7 +3908,8 @@
     "android": true,
     "expoGo": true,
     "fireos": true,
-    "unmaintained": true
+    "unmaintained": true,
+    "alternatives": ["react-native-enriched-markdown"]
   },
   {
     "githubUrl": "https://github.com/i18next/react-i18next",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3907,7 +3907,9 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "fireos": true
+    "fireos": true,
+    "unmaintained": true,
+    "alternatives": ["react-native-enriched-markdown"]
   },
   {
     "githubUrl": "https://github.com/i18next/react-i18next",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3908,8 +3908,7 @@
     "android": true,
     "expoGo": true,
     "fireos": true,
-    "unmaintained": true,
-    "alternatives": ["react-native-enriched-markdown"]
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/i18next/react-i18next",


### PR DESCRIPTION
## 📝 Why & how

Adds `react-native-enriched-markdown` as a recommended alternative for `react-native-markdown-display`, which was marked as unmaintained in #2460.

This PR is stacked on top of #2460 and should be merged after it.
