### PR TITLE
fill main data with `npmPkg` after diff check

### DIFF
--- a/scripts/validate-new-entries.ts
+++ b/scripts/validate-new-entries.ts
@@ -19,8 +19,10 @@ async function makeBaseFileQuery() {
 }
 
 const mainData = await makeBaseFileQuery();
-const mainDataWithNpmPkg = mainData.map(fillNpmName);
 const modifiedEntries = differenceWith(libraries, mainData, isEqual);
+const mainDataWithNpmPkg = mainData.map(fillNpmName);
+
+console.warn(modifiedEntries.length);
 
 if (modifiedEntries.length === 0) {
   console.log('✅ There was no data changes detected!');

--- a/scripts/validate-new-entries.ts
+++ b/scripts/validate-new-entries.ts
@@ -22,8 +22,6 @@ const mainData = await makeBaseFileQuery();
 const modifiedEntries = differenceWith(libraries, mainData, isEqual);
 const mainDataWithNpmPkg = mainData.map(fillNpmName);
 
-console.warn(modifiedEntries.length);
-
 if (modifiedEntries.length === 0) {
   console.log('✅ There was no data changes detected!');
   process.exit(0);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Since `.map` is a mutating operation CI check was incorrectly detecting libraries as modified.

Move main data `npmPkg` fill after diff count, so it won't affect the count check.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.
