### PR TITLE
Add munim-bluetooth to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21115,5 +21115,14 @@
   {
     "githubUrl": "https://github.com/fe-dudu/expo-ignore-battery-optimizations",
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/munimtechnologies/munim-bluetooth",
+    "examples": ["https://github.com/munimtechnologies/munim-bluetooth/tree/HEAD/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only",
+    "newArchitectureNote": "Built with Nitro Modules; the old architecture is not supported.",
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
# Why & how

This PR adds `munim-bluetooth` (https://github.com/munimtechnologies/munim-bluetooth) to the directory.

The package supports iOS and Android, includes an example app, ships an Expo config plugin, and is built on Nitro Modules, so it is marked as New Architecture only.

# Checklist

- [x] Added library to `react-native-libraries.json`
