### PR TITLE
Add expo-callkit-telecom to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21124,5 +21124,12 @@
     "newArchitecture": "new-arch-only",
     "newArchitectureNote": "Built with Nitro Modules; the old architecture is not supported.",
     "configPlugin": true
+  },
+  {
+    "githubUrl": "https://github.com/mfairley/expo-callkit-telecom",
+    "examples": ["https://github.com/mfairley/expo-callkit-telecom/tree/HEAD/example"],
+    "configPlugin": true,
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `expo-callkit-telecom` (https://github.com/mfairley/expo-callkit-telecom) package to the directory.

> [!NOTE]
> This is an automatic submission created via `rn-directory` CLI.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
