### PR TITLE
Add @clarionhq/recorder

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21132,7 +21132,7 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/Th4nderG0d/clarion",
+    "githubUrl": "https://github.com/Th4nderG0d/clarion/tree/main/packages/recorder",
     "npmPkg": "@clarionhq/recorder",
     "examples": ["https://github.com/Th4nderG0d/clarion/tree/main/example"],
     "ios": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21130,5 +21130,13 @@
     "configPlugin": true,
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/Th4nderG0d/clarion",
+    "npmPkg": "@clarionhq/recorder",
+    "examples": ["https://github.com/Th4nderG0d/clarion/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds [@clarionhq/recorder](https://www.npmjs.com/package/@clarionhq/recorder) — microphone capture for React Native (PCM → AAC m4a).

- Built on Nitro Modules
- New Architecture only (RN ≥ 0.77)
- 16 KB page-size compliant (Google Play mandate)
- iOS 15.1+, Android API 26+
- Verified end-to-end on both platforms via clean-room smoke test

Source: https://github.com/Th4nderG0d/clarion/tree/main/packages/recorder