### PR TITLE
Add react-native-agent to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21138,5 +21138,11 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/react-native-info/react-native-agent",
+    "newArchitecture": true,
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `react-native-agent` (https://github.com/react-native-info/react-native-agent) package to the directory.

> [!NOTE]
> This is an automatic submission created via `rn-directory` CLI.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
