### PR TITLE
Add @clarionhq/recognizer

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21140,6 +21140,14 @@
     "newArchitecture": true
   },
   {
+    "githubUrl": "https://github.com/Th4nderG0d/clarion/tree/main/packages/recognizer",
+    "npmPkg": "@clarionhq/recognizer",
+    "examples": ["https://github.com/Th4nderG0d/clarion/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
+  },
+  {
     "githubUrl": "https://github.com/react-native-info/react-native-agent",
     "newArchitecture": true,
     "ios": true,


### PR DESCRIPTION
Adds [`@clarionhq/recognizer`](https://www.npmjs.com/package/@clarionhq/recognizer) — a New Architecture wrapper for the platform speech recognizer (`SFSpeechRecognizer` on iOS, `SpeechRecognizer` on Android).

Part of the [Clarion](https://github.com/Th4nderG0d/clarion) monorepo (sibling to the already-listed `@clarionhq/recorder`). Built on Nitro Modules, 16 KB page-size compliant, iOS 15.1+ / Android API 26+.

Highlights:
- Partial + final transcripts, per-word segments on iOS (`startMs`, `durationMs`, `confidence`)
- Availability checks (`isAvailable(locale)`, `supportedLocales()`)
- Audio-level meter
- Cross-platform `TranscriptResult` with `id` / `sessionId` / `timestamp`

License: MIT.