### PR TITLE
Remove native-sass from the directory list (deprecated + repo removed)

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12851,17 +12851,6 @@
     "newArchitecture": true
   },
   {
-    "githubUrl": "https://github.com/nativesass/nativesass",
-    "npmPkg": "native-sass",
-    "ios": true,
-    "android": true,
-    "web": true,
-    "expoGo": true,
-    "newArchitecture": true,
-    "unmaintained": true,
-    "alternatives": ["@bibliolab/react-native-fluffle"]
-  },
-  {
     "githubUrl": "https://github.com/kore-koi/react-native-media-controller",
     "npmPkg": "@korekoi/react-native-media-controller",
     "examples": ["https://github.com/kore-koi/react-native-media-controller/tree/main/example"],

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12857,7 +12857,9 @@
     "android": true,
     "web": true,
     "expoGo": true,
-    "newArchitecture": true
+    "newArchitecture": true,
+    "unmaintained": true,
+    "alternatives": ["@bibliolab/react-native-fluffle"]
   },
   {
     "githubUrl": "https://github.com/kore-koi/react-native-media-controller",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

`native-sass` is [deprecated](https://www.npmjs.com/package/native-sass). This PR ~marks~ removes `native-sass` ~as unmaintained in~ from the React Native Directory and points users to its maintained successor, `@bibliolab/react-native-fluffle` (added to the list in PR #2472).

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [ ] Documented how you found or replicated the issue.
- [ ] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
