### PR TITLE
Add @react-navigation/core to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21197,5 +21197,13 @@
     "android": true,
     "web": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/react-navigation/react-navigation/tree/main/packages/core",
+    "npmPkg": "@react-navigation/core",
+    "newArchitecture": true,
+    "ios": true,
+    "android": true,
+    "web": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `@react-navigation/core` (https://github.com/react-navigation/react-navigation/tree/main/packages/core) package to the directory.

> [!NOTE]
> This is an automatic submission created via `rn-directory` CLI.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
