### PR TITLE
Add react-native-yandex-map

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21224,5 +21224,11 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/novev9/react-native-yandex-map",
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Add [`react-native-yandex-map`](https://github.com/novev9/react-native-yandex-map) — Fabric / New Architecture binding for Yandex MapKit Mobile SDK on RN 0.85+.

Supports map view, markers with React-rendered content, polylines / polygons / circles, clustered placemarks with per-point labels, search / suggest / reverse geocode, locale, and user location.

- iOS, Android
- New Architecture (Fabric + Turbo Modules) only