### PR TITLE
Add @clarionhq/azure

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21133,6 +21133,14 @@
     "newArchitecture": true
   },
   {
+    "githubUrl": "https://github.com/Th4nderG0d/clarion/tree/main/packages/azure",
+    "npmPkg": "@clarionhq/azure",
+    "examples": ["https://github.com/Th4nderG0d/clarion/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
+  },
+  {
     "githubUrl": "https://github.com/react-native-info/react-native-agent",
     "newArchitecture": true,
     "ios": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21133,14 +21133,6 @@
     "newArchitecture": true
   },
   {
-    "githubUrl": "https://github.com/Th4nderG0d/clarion/tree/main/packages/azure",
-    "npmPkg": "@clarionhq/azure",
-    "examples": ["https://github.com/Th4nderG0d/clarion/tree/main/example"],
-    "ios": true,
-    "android": true,
-    "newArchitecture": true
-  },
-  {
     "githubUrl": "https://github.com/react-native-info/react-native-agent",
     "newArchitecture": true,
     "ios": true,
@@ -21242,6 +21234,14 @@
   {
     "githubUrl": "https://github.com/novev9/react-native-instagram-stories",
     "npmPkg": "@novev9/react-native-instagram-stories",
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/Th4nderG0d/clarion/tree/main/packages/azure",
+    "npmPkg": "@clarionhq/azure",
+    "examples": ["https://github.com/Th4nderG0d/clarion/tree/main/example"],
     "ios": true,
     "android": true,
     "newArchitecture": true


### PR DESCRIPTION
Adds `@clarionhq/azure` — a React Native wrapper around the Microsoft Cognitive Services Speech SDK for streaming speech-to-text with per-word timestamps, speaker diarization, custom vocab biasing, mid-session network resilience, and structured errors.

Built on the New Architecture via [Nitro Modules](https://nitro.margelo.com). iOS 15.1+ / Android API 26+. 16 KB page-size compliant on Android.

- npm: https://www.npmjs.com/package/@clarionhq/azure
- repo: https://github.com/Th4nderG0d/clarion/tree/main/packages/azure
- example: https://github.com/Th4nderG0d/clarion/tree/main/example

Sibling packages already in the directory:
- `@clarionhq/recorder`
- `@clarionhq/recognizer`