### PR TITLE
Add expo-block-store

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21245,5 +21245,10 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/Navipro70/expo-block-store",
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds **expo-block-store** — an Expo module wrapping the Android [Block Store API](https://developer.android.com/identity/block-store) (Google Play services). It lets apps persist small tokens/identifiers that survive app uninstall/reinstall and transfer to a new device, with no sign-in. iOS and web are safe no-ops.

- npm: https://www.npmjs.com/package/expo-block-store
- repo: https://github.com/Navipro70/expo-block-store

Entry: Android-only native (`newArchitecture: true`, built with the Expo Modules API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)