### PR TITLE
Add react-native-rotary-timer to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21264,5 +21264,14 @@
     "android": true,
     "newArchitecture": "new-arch-only",
     "newArchitectureNote": "Fabric/TurboModule binding for 2GIS Mobile SDK 13.5; requires React Native 0.85+ with the New Architecture enabled."
+  },
+  {
+    "githubUrl": "https://github.com/DmytroMelnyk26/react-native-rotary-timer",
+    "examples": ["https://github.com/DmytroMelnyk26/react-native-rotary-timer/tree/HEAD/example"],
+    "newArchitecture": true,
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `react-native-rotary-timer` (https://github.com/DmytroMelnyk26/react-native-rotary-timer) package to the directory.

> [!NOTE]
> This is an automatic submission created via `rn-directory` CLI.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
