### PR TITLE
Add react-native-enriched-markdown alternatives for legacy markdown libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1496,7 +1496,8 @@
     "githubUrl": "https://github.com/CharlesMangwa/react-native-simple-markdown",
     "ios": true,
     "android": true,
-    "expoGo": true
+    "expoGo": true,
+    "alternatives": ["react-native-enriched-markdown"]
   },
   {
     "githubUrl": "https://github.com/gnestor/react-native-statusbar-alert",
@@ -1980,7 +1981,8 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "unmaintained": true
+    "unmaintained": true,
+    "alternatives": ["react-native-enriched-markdown"]
   },
   {
     "githubUrl": "https://github.com/superdami/react-native-custom-navigation",
@@ -4641,7 +4643,8 @@
     "githubUrl": "https://github.com/TitanInvest/react-native-easy-markdown",
     "ios": true,
     "android": true,
-    "expoGo": true
+    "expoGo": true,
+    "alternatives": ["react-native-enriched-markdown"]
   },
   {
     "githubUrl": "https://github.com/mkuczera/react-native-haptic-feedback",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1497,6 +1497,7 @@
     "ios": true,
     "android": true,
     "expoGo": true,
+    "unmaintained": true,
     "alternatives": ["react-native-enriched-markdown"]
   },
   {
@@ -4644,6 +4645,7 @@
     "ios": true,
     "android": true,
     "expoGo": true,
+    "unmaintained": true,
     "alternatives": ["react-native-enriched-markdown"]
   },
   {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Adds `react-native-enriched-markdown` as the recommended alternative for three unmaintained markdown libraries: `react-native-simple-markdown`, `react-native-markdown`, and `react-native-easy-markdown`.
These libraries are no longer maintained, but still appear in search results and get regular downloads. Recommending `react-native-enriched-markdown` helps guide developers toward a modern, actively maintained option with New Architecture support.

<img width="1186" height="641" alt="Zrzut ekranu 2026-06-8 o 16 04 58" src="https://github.com/user-attachments/assets/baadffde-db33-4246-8971-063a07c5a8e3" />

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [ ] Documented how you found or replicated the issue.
- [ ] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
