### PR TITLE
Set "newArchitecture": true for stripe-terminal-react-native

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -18072,7 +18072,8 @@
     "npmPkg": "@stripe/stripe-terminal-react-native",
     "examples": ["https://github.com/stripe/stripe-terminal-react-native/tree/main/example-app"],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/AgoraIO-Extensions/react-native-agora",


### PR DESCRIPTION
Set "newArchitecture": true for stripe-terminal-react-native

# 📝 Why & how

The stripe-terminal-react-native currently is rely on the interop layer but we've test on every release with test-app which is newArchitecture enabled. So we'd like to set the newArchitecture flag to true if possible.  

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [ ] Documented how you found or replicated the issue.
- [ ] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
