### PR TITLE
Add react-native-halo-menu to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21443,5 +21443,16 @@
     "examples": ["https://github.com/bhargavkanda/react-native-image-stitcher/tree/main/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/thegruber/react-native-halo-menu",
+    "examples": ["https://github.com/thegruber/react-native-halo-menu/tree/main/example"],
+    "images": [
+      "https://raw.githubusercontent.com/thegruber/react-native-halo-menu/main/docs/assets/halo-menu-showcase.webp"
+    ],
+    "newArchitecture": "new-arch-only",
+    "ios": true,
+    "android": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `react-native-halo-menu` (https://github.com/thegruber/react-native-halo-menu) package to the directory.

> [!NOTE]
> This is an automatic submission created via `rn-directory` CLI.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
