### PR TITLE
Add new library entry for react-native-smart-grid

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21451,5 +21451,13 @@
     "ios": true,
     "android": true,
     "web": true
-  }
+  },
+  {
+    "githubUrl": "https://github.com/warlock001/react-native-smart-grid",
+    "newArchitecture": true,
+    "configPlugin": true,
+    "ios": true,
+    "android": true,
+    "web": true
+  },
 ]


### PR DESCRIPTION
# 📝 Why & how

Adding `react-native-smart-grid` — a draggable, variable-sized tile grid for React Native.

There is currently no library in the RN ecosystem that supports mixed tile sizes (1×1, 2×2, 1×4, etc.) in a draggable grid. Existing grid/list libraries only support uniform tile sizes.

**Features:**
- Variable-sized tiles with drag-and-drop reordering
- Collision detection (push and swap modes)
- Auto-arrange via bin-packing algorithm
- Multi-select (long press enters selection mode)
- Resize handles in edit mode
- Gravity to compact layout after drops
- Save/restore layouts (storage-agnostic)
- Virtualized rendering — handles 1000+ tiles
- Zero extra dependencies beyond `react-native-gesture-handler` and `react-native-reanimated`

**npm:** https://www.npmjs.com/package/react-native-smart-grid  
**GitHub:** https://github.com/warlock001/react-native-smart-grid

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
