### PR TITLE
Add react-native-smart-grid library details

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21465,7 +21465,6 @@
   },
   {
     "githubUrl": "https://github.com/warlock001/react-native-smart-grid",
-    "npmPkg": "react-native-smart-grid",
     "examples": ["https://github.com/warlock001/react-native-smart-grid/tree/main/example"],
     "images": [
       "https://github.com/warlock001/react-native-smart-grid/blob/main/docs/drag-drop.gif",
@@ -21474,7 +21473,6 @@
     ],
     "newArchitecture": true,
     "ios": true,
-    "android": true,
-    "web": false
+    "android": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -21451,5 +21451,19 @@
     "ios": true,
     "android": true,
     "web": true
+  },
+  {
+    "githubUrl": "https://github.com/warlock001/react-native-smart-grid",
+    "npmPkg": "react-native-smart-grid",
+    "examples": ["https://github.com/warlock001/react-native-smart-grid/tree/main/example"],
+    "images": [
+      "https://github.com/warlock001/react-native-smart-grid/blob/main/docs/drag-drop.gif",
+      "https://github.com/warlock001/react-native-smart-grid/blob/main/docs/multi-select.gif",
+      "https://github.com/warlock001/react-native-smart-grid/blob/main/docs/resize.gif"
+    ],
+    "newArchitecture": true,
+    "ios": true,
+    "android": true,
+    "web": false
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adding `react-native-smart-grid` — a draggable, variable-sized tile grid for React Native.

There is currently no library in the RN ecosystem that supports mixed tile sizes (1×1, 2×2, 1×4, etc.) in a draggable grid. Existing grid/list libraries only support uniform tile sizes.

**Features:**
- Variable-sized tiles with drag-and-drop reordering
- Collision detection (push and swap modes)
- Auto-arrange via bin-packing algorithm
- Multi-select (long press enters selection mode)
- Resize handles in edit mode
- Gravity to compact layout after drops
- Save/restore layouts (storage-agnostic)
- Virtualized rendering — handles 1000+ tiles
- Zero extra dependencies beyond `react-native-gesture-handler` and `react-native-reanimated`

**npm:** https://www.npmjs.com/package/react-native-smart-grid  
**GitHub:** https://github.com/warlock001/react-native-smart-grid

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
