### PR TITLE
fix: restore CORS headers on /api/libraries

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -50,6 +50,13 @@ export default withPlugins([withExpo, withImages, withFonts, withBundleAnalyzer]
   async headers() {
     return [
       {
+        source: '/api/libraries',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Methods', value: 'GET,HEAD' },
+        ],
+      },
+      {
         source: '/fonts/:path*',
         headers: [{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }],
       },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

PR #2520 rewrote the headers() array in `next.config.ts` and inadvertently dropped the existing `/api/libraries` CORS entry. As a result, the endpoint stopped sending Access-Control-Allow-Origin in production.

<img width="1910" height="130" alt="CleanShot 2026-06-15 at 16 39 32@2x" src="https://github.com/user-attachments/assets/7111136a-0d1e-49e3-b4fa-1913b6af922f" />


This breaks every cross-origin browser consumer of the API. In particular, the React Native Directory results in the Expo docs search command menu (docs.expo.dev) now fail with "blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present" followed by `"Uncaught (in promise) TypeError: Failed to fetch"`, which takes down the whole search dialog rather than just the directory section.

This PR re-adds the `/api/libraries` CORS rule to the headers() array in `next.config.ts`.


# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
