### PR TITLE
use unpkg to check for README file existence in bundle

### DIFF
--- a/scripts/build-and-score-data.ts
+++ b/scripts/build-and-score-data.ts
@@ -1,4 +1,4 @@
-import { BlobAccessError, put } from '@vercel/blob';
+﻿import { BlobAccessError, put } from '@vercel/blob';
 import { chunk } from 'es-toolkit/array';
 import fs from 'node:fs';
 
@@ -10,6 +10,7 @@ import { type DataAssetType, type LibraryDataEntryType, type LibraryType } from 
 import { createCheckEndpointBlob, fetchLatestData, readLocalDataFile } from '~/util/blob';
 import { DATA_PATH } from '~/util/Constants';
 import { isLaterThan, TimeRange } from '~/util/datetime';
+import { backfillUnpkgReadmeFile } from '~/util/scoring';
 import { isEmptyOrNull } from '~/util/strings';
 
 import { calculateDirectoryScore, calculatePopularityScore } from './calculate-score';
@@ -171,6 +172,15 @@ export async function buildAndScoreData() {
   data = await fetchNightlyProgramData(data);
 
   console.log('\n⚛️ Calculating Directory Score');
+  data = await Promise.all(
+    data.map(async lib => {
+      if (!lib.npm?.hasReadme && !lib.github.hasReadme) {
+        return await backfillUnpkgReadmeFile(lib);
+      }
+      return lib;
+    })
+  );
+
   data = data.map(project => {
     try {
       return calculateDirectoryScore(project);

--- a/scripts/recalculate-scores.ts
+++ b/scripts/recalculate-scores.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { type DataAssetType } from '~/types';
-import { MAX_SCORE, MIN_SCORE } from '~/util/scoring';
+import { backfillUnpkgReadmeFile, MAX_SCORE, MIN_SCORE } from '~/util/scoring';
 
 import data from '../assets/data.json';
 
@@ -16,7 +16,17 @@ console.log('Min score:', MIN_SCORE);
 console.log('Max score:', MAX_SCORE);
 
 const { libraries, ...rest } = data as DataAssetType;
-const processedLibraries = libraries
+
+const librariesWithUnpkg = await Promise.all(
+  libraries.map(async lib => {
+    if (!lib.npm?.hasReadme && !lib.github.hasReadme) {
+      return await backfillUnpkgReadmeFile(lib);
+    }
+    return lib;
+  })
+);
+
+const processedLibraries = librariesWithUnpkg
   .map(lib => calculatePopularityScore(lib))
   .map(lib => calculateDirectoryScore(lib));
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -133,6 +133,9 @@ export type LibraryType = LibraryDataEntryType & {
     latestReleaseDate?: string;
     hasReadme?: boolean;
   };
+  unpkg?: {
+    hasReadme?: boolean;
+  };
   npmPkg: string;
   score: number;
   matchingScoreModifiers: string[];

--- a/util/scoring.ts
+++ b/util/scoring.ts
@@ -37,7 +37,8 @@ export const SCORING_CRITERIONS: ScoringCriterionType[] = [
     name: 'Has a README file',
     description: 'Libraries that have a README file included meet this criterion.',
     value: 10,
-    condition: data => data.github?.hasReadme ?? data.npm?.hasReadme ?? false,
+    condition: data =>
+      data.unpkg?.hasReadme ?? data.github?.hasReadme ?? data.npm?.hasReadme ?? false,
   },
   {
     name: 'Has a description',
@@ -154,4 +155,15 @@ export function getPopularityGrade(popularity: number) {
   } else {
     return 'Declining';
   }
+}
+
+export async function backfillUnpkgReadmeFile(lib: LibraryType) {
+  const res = await fetch(
+    `https://reactnative.directory/api/proxy/unpkg?name=${lib.npmPkg}&path=README.md`
+  );
+  if (res.status === 200) {
+    lib.unpkg = { hasReadme: true };
+    return lib;
+  }
+  return lib;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Fixes #2389
* #2389

Use unpkg proxy endpoint to check for README file existence in bundle if npm and GitHub fails to detect the file. Apply same changes to the recalculate script, make sure that scoring is updated correctly.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

<img width="1183" height="1012" alt="Screenshot 2026-06-15 163426" src="https://github.com/user-attachments/assets/eb701c60-d40f-4295-837e-3e6b3f4a5b70" />
