### PR TITLE
remove bunVersion from the Vercel config

### DIFF
--- a/vercel-quick.json
+++ b/vercel-quick.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "bunVersion": "1.x",
   "buildCommand": "bun build:quick",
   "build": {
     "env": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "bunVersion": "1.x",
   "build": {
     "env": {
       "GITHUB_TOKEN": "@github_token"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Unfortunately using Bun runtime leads to some unexpected function errors.

Removing `bunVersion` from the Vercel config to revert to the default runner for now.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.
