### PR TITLE
async import image scrape util, skip Bun fetch usage in image scrape

### DIFF
--- a/scripts/build-and-score-data.ts
+++ b/scripts/build-and-score-data.ts
@@ -16,7 +16,6 @@ import { isEmptyOrNull } from '~/util/strings';
 import { calculateDirectoryScore, calculatePopularityScore } from './calculate-score';
 import { fetchGithubData, fetchGithubRateLimit, loadGitHubLicenses } from './fetch-github-data';
 import fetchNightlyProgramData from './fetch-nightly-program-data';
-import fetchReadmeImages from './fetch-readme-images';
 import { fillNpmName, hasMismatchedPackageData, sleep } from './helpers';
 
 // Uses debug-github-repos.json instead, so we have less repositories to crunch
@@ -133,6 +132,7 @@ export async function buildAndScoreData() {
 
   if (SCRAPE_GH_IMAGES) {
     console.log('\n📝 Scraping images from README');
+    const { fetchReadmeImages } = await import('./fetch-readme-images');
     data = await Promise.all(data.map(project => fetchReadmeImages(project)));
   }
 

--- a/scripts/build-and-score-data.ts
+++ b/scripts/build-and-score-data.ts
@@ -15,7 +15,7 @@ import { isEmptyOrNull } from '~/util/strings';
 
 import { calculateDirectoryScore, calculatePopularityScore } from './calculate-score';
 import { fetchGithubData, fetchGithubRateLimit, loadGitHubLicenses } from './fetch-github-data';
-import fetchNightlyProgramData from './fetch-nightly-program-data';
+import { fetchNightlyProgramData } from './fetch-nightly-program-data';
 import { fillNpmName, hasMismatchedPackageData, sleep } from './helpers';
 
 // Uses debug-github-repos.json instead, so we have less repositories to crunch

--- a/scripts/fetch-nightly-program-data.ts
+++ b/scripts/fetch-nightly-program-data.ts
@@ -2,7 +2,7 @@ import { makeGraphqlQuery } from '~/scripts/helpers';
 import GitHubNightlyProgramQuery from '~/scripts/queries/GitHubNightlyProgramQuery';
 import { type LibraryType, type NightlyProgramData } from '~/types';
 
-export default async function fetchNightlyProgrammeData(list: LibraryType[]) {
+export async function fetchNightlyProgramData(list: LibraryType[]) {
   const result = await makeGraphqlQuery(GitHubNightlyProgramQuery);
 
   const nightlyData = JSON.parse(result.data.repository.librariesJson.text) as Record<

--- a/scripts/fetch-readme-images.ts
+++ b/scripts/fetch-readme-images.ts
@@ -1,4 +1,3 @@
-import { fetch } from 'bun';
 import { type Cheerio, load } from 'cheerio';
 
 import { type LibraryType } from '~/types';

--- a/scripts/fetch-readme-images.ts
+++ b/scripts/fetch-readme-images.ts
@@ -42,7 +42,7 @@ async function scrapeImagesAsync(githubUrl: string) {
   }
 }
 
-async function fetchReadmeImages(data: LibraryType, attemptsCount = 0) {
+export async function fetchReadmeImages(data: LibraryType, attemptsCount = 0) {
   /**
    * @DEV
    * if images been set, or max attempt count has been reached, we skip scraping images
@@ -66,5 +66,3 @@ async function fetchReadmeImages(data: LibraryType, attemptsCount = 0) {
     return await fetchReadmeImages(data, attemptsCount + 1);
   }
 }
-
-export default fetchReadmeImages;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Skip Bun fetch usage in image scrape. It's not used at PROD, but still imported.

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [ ] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
