### PR TITLE
Add @kesha-antonov/react-native-chat, mark react-native-gifted-chat as unmaintained

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3925,7 +3925,9 @@
     "examples": [
       "https://snack.expo.dev/@xcarpentier/giftedchat-playground",
       "https://reverent-bardeen-47c862.netlify.app/"
-    ]
+    ],
+    "unmaintained": true,
+    "alternatives": ["@kesha-antonov/react-native-chat"]
   },
   {
     "githubUrl": "https://github.com/shoutem/ui",
@@ -21710,5 +21712,13 @@
     "examples": ["https://github.com/blazejkustra/blaze-navigation/tree/main/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/kesha-antonov/react-native-chat",
+    "npmPkg": "@kesha-antonov/react-native-chat",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
Hello from the maintainer of [react-native-gifted-chat](https://github.com/FaridSafi/react-native-gifted-chat)!

I'm deprecating `react-native-gifted-chat` in favor of the new `@kesha-antonov/react-native-chat` library which I also maintain.

Changes:
- Marked `react-native-gifted-chat` as `unmaintained: true` and added `@kesha-antonov/react-native-chat` as the suggested alternative
- Added `@kesha-antonov/react-native-chat` (https://github.com/kesha-antonov/react-native-chat) as a new entry