### PR TITLE
Add token-based matching to improve search recall for non-contiguous package names

### DIFF
--- a/util/search.ts
+++ b/util/search.ts
@@ -25,13 +25,6 @@ function calculateMatchScore(
       ? 150
       : 0;
 
-  const npmPkgNameMatchPoints =
-    !isEmptyOrNull(npmPkg) &&
-    (npmPkg.includes(querySearch) ||
-      npmPkg.replaceAll(NPM_NAME_CLEANUP_REGEX, ' ').toLowerCase().includes(querySearch))
-      ? 125
-      : 0;
-
   const cleanedUpName = npmPkg
     .replace('react-native', '')
     .replace('react', '')
@@ -39,12 +32,33 @@ function calculateMatchScore(
     .toLowerCase()
     .trim();
 
+  const cleanedUpQuery = querySearch
+    .replace('react-native', '')
+    .replace('react', '')
+    .replaceAll(NPM_NAME_CLEANUP_REGEX, ' ')
+    .trim();
+
+  const queryTokens = cleanedUpQuery.split(/\s+/).filter(Boolean);
+  const allTokensMatch =
+    queryTokens.length > 0 && queryTokens.every(token => cleanedUpName.includes(token));
+
+  const npmPkgNameMatchPoints =
+    !isEmptyOrNull(npmPkg) &&
+    (npmPkg.includes(querySearch) ||
+      npmPkg.replaceAll(NPM_NAME_CLEANUP_REGEX, ' ').toLowerCase().includes(querySearch))
+      ? 125
+      : !isEmptyOrNull(npmPkg) && allTokensMatch
+        ? 100
+        : 0;
+
   const cleanedUpNameMatchPoints =
     !isEmptyOrNull(cleanedUpName) &&
     (cleanedUpName.includes(querySearch) ||
       cleanedUpName.includes(querySearch.replaceAll(NPM_NAME_CLEANUP_REGEX, ' ')))
       ? 100
-      : 0;
+      : !isEmptyOrNull(cleanedUpName) && allTokensMatch
+        ? 75
+        : 0;
 
   const gitHubURLOrOwnerMatchPoints =
     githubUrl.startsWith(querySearch) ||
@@ -53,7 +67,11 @@ function calculateMatchScore(
       : 0;
 
   const repoNameMatchPoints =
-    !isEmptyOrNull(github.name) && github.name.toLowerCase().includes(querySearch) ? 50 : 0;
+    !isEmptyOrNull(github.name) && github.name.toLowerCase().includes(querySearch)
+      ? 50
+      : !isEmptyOrNull(github.name) && allTokensMatch
+        ? 35
+        : 0;
 
   const vegaOSPackageMatchPoints =
     typeof vegaos === 'string' && vegaos.includes(querySearch) ? 25 : 0;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Improves search recall for libraries whose names contain all the query words but not as a contiguous substring.

**Problem:** Searching for `react-native-markdown` would not surface libraries like `react-native-enriched-markdown` or `react-native-live-markdown` in the `cleanedUpNameMatchPoints`, `npmPkgNameMatchPoints`, and `repoNameMatchPoints` scoring tiers, because those tiers only checked for contiguous substring matches. The word `enriched`/`live` in the middle broke the match entirely, scoring 0.

**Solution:** After stripping the `react-native`/`react` prefix from both the query and package name, split into tokens and check if every token appears in the cleaned-up name. This adds a fallback scoring tier to three match checks:

- `npmPkgNameMatchPoints`: 125 (contiguous) → **100 (token match)** → 0
- `cleanedUpNameMatchPoints`: 100 (contiguous) → **75 (token match)** → 0
- `repoNameMatchPoints`: 50 (contiguous) → **35 (token match)** → 0

Contiguous substring matches still score higher, so a library like `react-native-markdown-renderer` correctly ranks above `react-native-enriched-markdown` for the query `react-native-markdown` — but both now appear in results instead of only the former.


https://github.com/user-attachments/assets/0d3d8cdb-b406-4cfa-af08-2acbe78a7db2

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [ ] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [x] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
