### PR TITLE
fix: retry npm downloads API on 429 status (rate-limit retry never fired)

### DIFF
--- a/scripts/fetch-npm-download-data.ts
+++ b/scripts/fetch-npm-download-data.ts
@@ -18,6 +18,18 @@ export async function fetchNpmDownloadData(pkgData: LibraryType, attemptsCount =
     const response = await fetch(url);
 
     if (response.status !== 200) {
+      // Rate limiting comes back as a 429 status (and transient outages as 5xx).
+      // fetch does not throw on these, so without this they skip the catch block
+      // below where the retry lives, and a single 429 fails the entry. Retry them
+      // with the same backoff the catch uses.
+      if ((response.status === 429 || response.status >= 500) && attemptsCount < ATTEMPTS_LIMIT) {
+        await sleep(REQUEST_SLEEP, REQUEST_SLEEP * 2);
+        console.log(
+          `⬇️ [NPM DOWNLOADS API] status ${response.status} for ${npmPkg}, retrying (${attemptsCount + 1})`
+        );
+        return await fetchNpmDownloadData(pkgData, attemptsCount + 1);
+      }
+
       console.error(
         `⬇️ [NPM DOWNLOADS API] npm API has returned invalid response - status ${response.status}!`
       );


### PR DESCRIPTION
## Problem

`scripts/fetch-npm-download-data.ts` has a retry path whose own log messages describe it as handling the npm rate limit ("Looks like we have reached the npm API rate limit!", "Retrying fetch for ..."). That retry lives in the `catch` block, which only runs when `fetch` throws. The npm downloads API signals rate limiting with an HTTP 429 status, and `fetch` does not throw on a 429. So a 429 hits the `if (response.status !== 200)` branch first and returns `{ npm: null }`, and the retry never runs.

The effect shows up in `scripts/validate-new-entries.ts` (`bun ci:validate`), which makes one downloads call per changed entry. A `npm: null` result fails that entry's check, so a PR touching enough entries to brush the rate limit fails CI on a transient 429 with no recovery. The limit is a rolling window that hits a different subset each time, so re-running fails on a different entry instead of passing.

## Evidence

I replayed `validate-new-entries`'s request pacing (batches of 5, 1s stagger, 3s between batches) against the real `api.npmjs.org/downloads` endpoint. The rate limit comes back as a 429 status every time: a 60-request burst returned 60 responses with status 429 and 0 thrown errors. So these responses currently take the no-retry status branch rather than the `catch`.

## Fix

Handle 429 (and transient 5xx) with the same `REQUEST_SLEEP` backoff and `ATTEMPTS_LIMIT` retry the `catch` already uses, before falling through to the error return. Permanent failures (404, malformed body, retries exhausted) still return `{ npm: null }` as before.

The change is about 16 lines, reuses the existing retry code, adds no dependencies, and passes `oxlint --type-aware && oxfmt --check`.
