### PR TITLE
validate new/updated entries sequentially

### DIFF
--- a/scripts/fetch-github-data.ts
+++ b/scripts/fetch-github-data.ts
@@ -18,7 +18,7 @@ import { getUpdatedUrl, makeGraphqlQuery, processTopics, REQUEST_SLEEP, sleep } 
 import GitHubLicensesQuery from './queries/GitHubLicensesQuery';
 import GitHubRepositoryQuery from './queries/GitHubRepositoryQuery';
 
-config();
+config({ quiet: true });
 
 const licenses: Record<string, LibraryLicenseType> = {
   isc: {

--- a/scripts/validate-new-entries.ts
+++ b/scripts/validate-new-entries.ts
@@ -27,141 +27,141 @@ if (modifiedEntries.length === 0) {
   process.exit(0);
 }
 
-console.log('🚩️ Detected changes in data entries, checking!');
+console.log(`🚩️ Detected ${modifiedEntries.length} changes in data entries, validating!`);
 
 const BATCH_SIZE = 5;
-const STAGGER_MS = 1000;
-const BATCH_DELAY_MS = 3000;
+const BATCH_DELAY_MS = 2500;
 
 const checkResults = [];
 
 for (let i = 0; i < modifiedEntries.length; i += BATCH_SIZE) {
   const batch = modifiedEntries.slice(i, i + BATCH_SIZE);
 
-  const batchResults = await Promise.all(
-    batch.map(entry =>
-      (async () => {
-        await sleep(STAGGER_MS);
+  for (const entry of batch) {
+    const entryWithNpmData = await fetchNpmDownloadData(fillNpmName(entry));
 
-        const entryWithNpmData = await fetchNpmDownloadData(fillNpmName(entry));
+    if (!entryWithNpmData.npm) {
+      console.error(
+        `Unable to fetch npm package data for ${entryWithNpmData.npmPkg} package! Please make sure that the package exist in npm registry.`
+      );
+      console.error(
+        `For the new packages recently published for the first time, npm API can return non-existing package error. The resolution here is to wait up to 24h, and then re-trigger the CI workflow.`
+      );
+      console.error(
+        `To check the current API response visit: https://api.npmjs.org/downloads/point/last-month/${entryWithNpmData.npmPkg}`
+      );
+      checkResults.push(false);
+      continue;
+    }
 
-        if (!entryWithNpmData.npm) {
-          console.error(
-            `Unable to fetch npm package data for ${entryWithNpmData.npmPkg} package! Please make sure that the package exist in npm registry.`
-          );
-          console.error(
-            `For the new packages recently published for the first time, npm API can return non-existing package error. The resolution here is to wait up to 24h, and then re-trigger the CI workflow.`
-          );
-          console.error(
-            `To check the current API response visit: https://api.npmjs.org/downloads/point/last-month/${entryWithNpmData.npmPkg}`
-          );
-          return false;
+    const entryWithGitHubData = await fetchGithubData(entryWithNpmData);
+
+    if (!entryWithGitHubData.github) {
+      console.error(
+        `Unable to fetch data from ${entryWithGitHubData.githubUrl} repository! Make sure that repository is public, and URL is correct.`
+      );
+      checkResults.push(false);
+      continue;
+    }
+
+    if (entryWithGitHubData.github.isPrivate === true) {
+      console.error(
+        `Extracted 'package.json' from ${entryWithGitHubData.githubUrl} is marked as private! You might be linking to the monorepo/workspace root, instead of wanted package directory.`
+      );
+      checkResults.push(false);
+      continue;
+    }
+
+    if (!entryWithGitHubData.github.name) {
+      console.error(
+        `Extracted 'package.json' from ${entryWithGitHubData.githubUrl} does not contains package name! You might be linking to the monorepo/workspace root, instead of wanted package directory.`
+      );
+      checkResults.push(false);
+      continue;
+    }
+
+    if (hasMismatchedPackageData(entryWithGitHubData)) {
+      console.error(
+        `Package name extracted from 'package.json' at given GitHub repository URL differs with package name in the directory data!`
+      );
+      console.error(
+        `- Supplied package name: ${entryWithGitHubData.npmPkg ?? entryWithGitHubData.githubUrl.split('/').at(-1)}`
+      );
+      console.error(
+        `- Extracted package name: ${entryWithGitHubData.github.name ?? entryWithGitHubData.github.fullName.split('/').at(-1)}`
+      );
+      console.error(
+        `If package is a part of monorepo, 'githubUrl' must point to directory where 'package.json' for a given package resides.`
+      );
+
+      checkResults.push(false);
+      continue;
+    }
+
+    const invalidKeys = Object.keys(entry).filter(key => !VALID_ENTRY_KEYS.has(key));
+
+    if (invalidKeys.length > 0) {
+      console.error(
+        `Package entry for '${entryWithGitHubData.npmPkg}' contains invalid fields: ${invalidKeys.map(key => `'${key}'`).join(', ')}. Correct or remove the listed keys to fix the definition.`
+      );
+      checkResults.push(false);
+      continue;
+    }
+
+    if (mainData.some(({ githubUrl }) => githubUrl === entryWithNpmData.githubUrl)) {
+      if (entryWithGitHubData?.alternatives && entryWithGitHubData.alternatives.length > 0) {
+        const existingEntry = mainDataWithNpmPkg.find(
+          lib => lib.npmPkg === entryWithGitHubData.npmPkg
+        );
+
+        if (!existingEntry) {
+          console.error(`Cannot set alternatives for the package not listed in the directory.`);
+          checkResults.push(false);
+          continue;
         }
 
-        const entryWithGitHubData = await fetchGithubData(entryWithNpmData);
-
-        if (!entryWithGitHubData.github) {
+        if (!existingEntry.unmaintained && existingEntry.newArchitecture !== false) {
           console.error(
-            `Unable to fetch data from ${entryWithGitHubData.githubUrl} repository! Make sure that repository is public, and URL is correct.`
+            `Cannot set alternatives for the ${entryWithGitHubData.npmPkg} package which is not marked as unmaintained or not supporting New Architecture.`
           );
-          return false;
+          checkResults.push(false);
+          continue;
         }
+      }
+    }
 
-        if (entryWithGitHubData.github.isPrivate === true) {
-          console.error(
-            `Extracted 'package.json' from ${entryWithGitHubData.githubUrl} is marked as private! You might be linking to the monorepo/workspace root, instead of wanted package directory.`
-          );
-          return false;
-        }
-
-        if (!entryWithGitHubData.github.name) {
-          console.error(
-            `Extracted 'package.json' from ${entryWithGitHubData.githubUrl} does not contains package name! You might be linking to the monorepo/workspace root, instead of wanted package directory.`
-          );
-          return false;
-        }
-
-        if (hasMismatchedPackageData(entryWithGitHubData)) {
-          console.error(
-            `Package name extracted from 'package.json' at given GitHub repository URL differs with package name in the directory data!`
-          );
-          console.error(
-            `- Supplied package name: ${entryWithGitHubData.npmPkg ?? entryWithGitHubData.githubUrl.split('/').at(-1)}`
-          );
-          console.error(
-            `- Extracted package name: ${entryWithGitHubData.github.name ?? entryWithGitHubData.github.fullName.split('/').at(-1)}`
-          );
-          console.error(
-            `If package is a part of monorepo, 'githubUrl' must point to directory where 'package.json' for a given package resides.`
-          );
-
-          return false;
-        }
-
-        const invalidKeys = Object.keys(entry).filter(key => !VALID_ENTRY_KEYS.has(key));
-
-        if (invalidKeys.length > 0) {
-          console.error(
-            `Package entry for '${entryWithGitHubData.npmPkg}' contains invalid fields: ${invalidKeys.map(key => `'${key}'`).join(', ')}. Correct or remove the listed keys to fix the definition.`
-          );
-          return false;
-        }
-
-        if (mainData.some(({ githubUrl }) => githubUrl === entryWithNpmData.githubUrl)) {
-          if (entryWithGitHubData?.alternatives && entryWithGitHubData.alternatives.length > 0) {
-            const existingEntry = mainDataWithNpmPkg.find(
-              lib => lib.npmPkg === entryWithGitHubData.npmPkg
+    if (entryWithGitHubData?.alternatives && entryWithGitHubData.alternatives.length > 0) {
+      const alternativesChecks = entryWithGitHubData.alternatives.map(alternative => {
+        const alternativeEntry = mainDataWithNpmPkg.find(lib => lib.npmPkg === alternative);
+        if (alternativeEntry) {
+          if (alternativeEntry.unmaintained) {
+            console.error(
+              `${alternative} is marked as unmaintained in the directory, so it cannot be defined as an alternative for the package.`
             );
-
-            if (!existingEntry) {
-              console.error(`Cannot set alternatives for the package not listed in the directory.`);
-              return false;
-            }
-
-            if (!existingEntry.unmaintained && existingEntry.newArchitecture !== false) {
-              console.error(
-                `Cannot set alternatives for the ${entryWithGitHubData.npmPkg} package which is not marked as unmaintained or not supporting New Architecture.`
-              );
-              return false;
-            }
+            return false;
           }
-        }
-
-        if (entryWithGitHubData?.alternatives && entryWithGitHubData.alternatives.length > 0) {
-          const alternativesChecks = entryWithGitHubData.alternatives.map(alternative => {
-            const alternativeEntry = mainDataWithNpmPkg.find(lib => lib.npmPkg === alternative);
-            if (alternativeEntry) {
-              if (alternativeEntry.unmaintained) {
-                console.error(
-                  `${alternative} is marked as unmaintained in the directory, so it cannot be defined as an alternative for the package.`
-                );
-                return false;
-              }
-            } else {
-              const localDataAlternative = libraries.find(
-                lib => lib.npmPkg === alternative || lib.githubUrl.endsWith(alternative)
-              );
-              if (!localDataAlternative) {
-                console.error(
-                  `${alternative} is not listed in the directory, so it cannot be defined as an alternative for the package.`
-                );
-                return false;
-              }
-            }
-            return true;
-          });
-
-          if (alternativesChecks.includes(false)) {
+        } else {
+          const localDataAlternative = libraries.find(
+            lib => lib.npmPkg === alternative || lib.githubUrl.endsWith(alternative)
+          );
+          if (!localDataAlternative) {
+            console.error(
+              `${alternative} is not listed in the directory, so it cannot be defined as an alternative for the package.`
+            );
             return false;
           }
         }
-
         return true;
-      })()
-    )
-  );
+      });
 
-  checkResults.push(...batchResults);
+      if (alternativesChecks.includes(false)) {
+        checkResults.push(false);
+        continue;
+      }
+    }
+
+    checkResults.push(true);
+  }
 
   if (i + BATCH_SIZE < modifiedEntries.length) {
     await sleep(BATCH_DELAY_MS);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Change the script responsible to validate new/updated entries to do that sequentially instead of in parallel, to avoid rate limiting from 3rd pary APIs (mostly npm). This increases the script runtime slightly, but should ensure that there are no 429 responses for large batches (10+ entries changed).

Additional small tweaks:
* print out number of entries changed in the log message
* turn on quiet mode for `dotenv`

Refs:
* #2582

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

<img width="612" height="116" alt="Screenshot 2026-06-27 175419" src="https://github.com/user-attachments/assets/c4e3663d-4d1d-4b86-94f1-9945fcdf038d" />
