### PR TITLE
fix: allow legitimately-private single-package repos past the isPrivate check (#2584)

### DIFF
--- a/scripts/fetch-npm-download-data.ts
+++ b/scripts/fetch-npm-download-data.ts
@@ -37,6 +37,7 @@ export async function fetchNpmDownloadData(pkgData: LibraryType, attemptsCount =
       ...pkgData,
       npm: {
         downloads: downloadData.downloads,
+        package: downloadData.package,
       },
     };
   } catch (error) {

--- a/scripts/validate-new-entries.ts
+++ b/scripts/validate-new-entries.ts
@@ -65,11 +65,23 @@ for (let i = 0; i < modifiedEntries.length; i += BATCH_SIZE) {
     }
 
     if (entryWithGitHubData.github.isPrivate === true) {
-      console.error(
-        `Extracted 'package.json' from ${entryWithGitHubData.githubUrl} is marked as private! You might be linking to the monorepo/workspace root, instead of wanted package directory.`
-      );
-      checkResults.push(false);
-      continue;
+      // Some legitimately-published single-package repos keep their root
+      // `package.json` `private: true` as a publish guard (they ship a built
+      // artifact via CI). For those the extracted name still equals the package
+      // npm actually serves, so allow them past this guard. A genuine mislink to
+      // an unrelated/monorepo root has a name that differs from (or is absent
+      // for) the entry's package and is still rejected below.
+      const publishedName = entryWithNpmData.npm?.package;
+      const extractedName = entryWithGitHubData.github.name;
+      const isLegitPrivate = !!extractedName && !!publishedName && extractedName === publishedName;
+
+      if (!isLegitPrivate) {
+        console.error(
+          `Extracted 'package.json' from ${entryWithGitHubData.githubUrl} is marked as private! You might be linking to the monorepo/workspace root, instead of wanted package directory.`
+        );
+        checkResults.push(false);
+        continue;
+      }
     }
 
     if (!entryWithGitHubData.github.name) {


### PR DESCRIPTION
# 📝 Why & how

Fixes #2584.

`validate-new-entries` rejects any entry whose GitHub `package.json` is `private: true`, on the assumption it's a monorepo-root mislink. But several single-package repos (lodash, jotai, zustand, @legendapp/state, …) legitimately keep their root manifest `private: true` as a publish guard while shipping a built artifact via CI, so their Fire OS/other compatibility flags can never be added or updated.

Following the approach from the issue: compare the extracted `package.json` `name` against the `package` field the npm downloads API echoes back (already fetched per entry). When they match, the link points at the genuine published package, so it's allowed past the `isPrivate` guard. A real mislink to an unrelated/monorepo root has a name that differs from (or is absent for) the entry's package and is still rejected by the existing checks.

Changes:
- `fetch-npm-download-data.ts`: include the `package` field in the returned npm data (`validate-new-entries` is its only caller).
- `types/index.ts`: add `npm.package`.
- `validate-new-entries.ts`: relax the `isPrivate` rejection only when extracted name === published name.

Verified locally (`bun ci:validate`):
- lodash (root `private: true`, name `lodash`) now validates.
- a mislink (jotai repo claimed as npmPkg `react`) is still rejected.

# ✅ Checklist

- [x] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
