### PR TITLE
Add PostHog React Native plugin to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -22745,7 +22745,7 @@
     "vegaos": true
   },
   {
-    "githubUrl": "https://github.com/PostHog/posthog-js",
+    "githubUrl": "https://github.com/PostHog/posthog-js/tree/main/packages/react-native-plugin",
     "npmPkg": "@posthog/react-native-plugin",
     "ios": true,
     "android": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -22743,5 +22743,16 @@
     "fireos": true,
     "horizon": true,
     "vegaos": true
+  },
+  {
+    "githubUrl": "https://github.com/PostHog/posthog-js",
+    "npmPkg": "@posthog/react-native-plugin",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "newArchitecture": true,
+    "configPlugin": false,
+    "unmaintained": false,
+    "dev": false
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -22749,10 +22749,6 @@
     "npmPkg": "@posthog/react-native-plugin",
     "ios": true,
     "android": true,
-    "web": false,
-    "newArchitecture": true,
-    "configPlugin": false,
-    "unmaintained": false,
-    "dev": false
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds the @posthog/react-native-plugin library to the directory.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**