### PR TITLE
Mark @criipto/verify-expo as supporting the New Architecture

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -19524,10 +19524,11 @@
   {
     "githubUrl": "https://github.com/criipto/criipto-verify-expo",
     "npmPkg": "@criipto/verify-expo",
-    "examples": ["https://github.com/criipto/criipto-verify-expo/tree/master/example"],
+    "examples": ["https://github.com/criipto/criipto-verify-expo/tree/master/examples"],
     "ios": true,
     "android": true,
-    "fireos": true
+    "fireos": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/pagopa/io-app-design-system",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -19524,7 +19524,11 @@
   {
     "githubUrl": "https://github.com/criipto/criipto-verify-expo",
     "npmPkg": "@criipto/verify-expo",
-    "examples": ["https://github.com/criipto/criipto-verify-expo/tree/master/examples"],
+    "examples": [
+      "https://github.com/criipto/criipto-verify-expo/tree/master/examples/expo54",
+      "https://github.com/criipto/criipto-verify-expo/tree/master/examples/expo55",
+      "https://github.com/criipto/criipto-verify-expo/tree/master/examples/expo56"
+    ],
     "ios": true,
     "android": true,
     "fireos": true,


### PR DESCRIPTION
# 📝 Why & how

`@criipto/verify-expo` is an Expo Modules API module. It's architecture-agnostic at runtime and works under the New Architecture. It uses no React Native codegen, so it has no `codegenConfig` for the directory's automatic detection. 

I am the author of the module, and I have manually verified that it works with the new arch :).

Per the README ("Set `newArchitecture` field only when automatic architecture detection fails … despite it supports the New Architecture"), this sets the field manually.

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**