### PR TITLE
Add melta-app

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -22941,5 +22941,15 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/tsubotax/melta-app",
+    "examples": [
+      "https://app.melta.tsubotax.com"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
Adds [melta-app](https://github.com/tsubotax/melta-app) — a React Native (Expo-compatible) UI kit driven by design contracts (`melta-contracts` JSON as the single source of truth, shared with the web implementation).

- Entry added at the end of `react-native-libraries.json` following the template (skipped `false` values and optional fields)
- `npmPkg` omitted: npm package name matches the repository name ([npm](https://www.npmjs.com/package/melta-app))
- `examples`: live catalog built from the actual RN components via Expo web export — https://app.melta.tsubotax.com
- Pure JS/TS library (no native modules), so `newArchitecture` is left to automatic detection per the contributing guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)