### PR TITLE
Fix react-native-nitro-sqlite githubUrl to its monorepo package path

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13770,7 +13770,7 @@
     "fireos": true
   },
   {
-    "githubUrl": "https://github.com/margelo/react-native-nitro-sqlite/tree/main/package",
+    "githubUrl": "https://github.com/margelo/react-native-nitro-sqlite/tree/main/packages/react-native-nitro-sqlite",
     "npmPkg": "react-native-nitro-sqlite",
     "examples": ["https://github.com/margelo/react-native-nitro-sqlite/tree/main/example"],
     "ios": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13771,7 +13771,6 @@
   },
   {
     "githubUrl": "https://github.com/margelo/react-native-nitro-sqlite/tree/main/packages/react-native-nitro-sqlite",
-    "npmPkg": "react-native-nitro-sqlite",
     "examples": ["https://github.com/margelo/react-native-nitro-sqlite/tree/main/example"],
     "ios": true,
     "android": true,


### PR DESCRIPTION
# 📝 Why & how

The `githubUrl` for **react-native-nitro-sqlite** points to `/tree/main/package`, which doesn't exist — the repo is a monorepo and the published package lives at `packages/react-native-nitro-sqlite`. As a result `validate-new-entries` can't resolve the package's `package.json`.

Corrected the `githubUrl` to the actual package path:

`https://github.com/margelo/react-native-nitro-sqlite/tree/main/packages/react-native-nitro-sqlite`

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**
