### PR TITLE
Add react-native-quick-filter

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23081,7 +23081,6 @@
   },
   {
     "githubUrl": "https://github.com/nsozturk/react-native-quick-filter",
-    "npmPkg": "react-native-quick-filter",
     "ios": true,
     "android": true,
     "expoGo": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23078,5 +23078,13 @@
     "ios": true,
     "android": true,
     "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/nsozturk/react-native-quick-filter",
+    "npmPkg": "react-native-quick-filter",
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds [`react-native-quick-filter`](https://github.com/nsozturk/react-native-quick-filter) — a reusable quick-filter flow for React Native & Expo: a horizontal chip/pill bar, chip dropdowns, and a slide-in filter panel (drilldown, Amazon-style master-detail, and MediaMarkt-style sheet) with sort, faceted counts, a live result counter, i18n and light/dark theming. Headless core + themed UI.

- npm: https://www.npmjs.com/package/react-native-quick-filter
- Repo: https://github.com/nsozturk/react-native-quick-filter
- JS-only (no native module) → iOS, Android, Expo Go, New Architecture.