### PR TITLE
Add react-native-quick-preview

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23078,5 +23078,20 @@
     "ios": true,
     "android": true,
     "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/Hashtagsmile/react-native-quick-preview",
+    "npmPkg": "react-native-quick-preview",
+    "examples": [
+      "https://github.com/Hashtagsmile/react-native-quick-preview/tree/main/apps/expo-quick-preview-example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/Hashtagsmile/react-native-quick-preview/main/demo-feed.gif",
+      "https://raw.githubusercontent.com/Hashtagsmile/react-native-quick-preview/main/demo-shop.gif"
+    ],
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23080,7 +23080,7 @@
     "dev": true
   },
   {
-    "githubUrl": "https://github.com/Hashtagsmile/react-native-quick-preview",
+    "githubUrl": "https://github.com/Hashtagsmile/react-native-quick-preview/tree/main/packages/react-native-quick-preview",
     "npmPkg": "react-native-quick-preview",
     "examples": [
       "https://github.com/Hashtagsmile/react-native-quick-preview/tree/main/apps/expo-quick-preview-example"


### PR DESCRIPTION
Adds [`react-native-quick-preview`](https://www.npmjs.com/package/react-native-quick-preview) — a headless long-press "peek" preview for React Native.

Long-press an item to peek its content in a popover or sheet, then tap to open the full screen. Unlike iOS-only options (native context-menu libraries, Expo Router's `Link.Preview`), it renders arbitrary content identically on **iOS and Android**, needs no native module, and runs in Expo Go.

- npm: https://www.npmjs.com/package/react-native-quick-preview
- Repo: https://github.com/Hashtagsmile/react-native-quick-preview
- Example app (7 real-world screens): https://github.com/Hashtagsmile/react-native-quick-preview/tree/main/apps/expo-quick-preview-example

MIT · published with provenance · TypeScript types + full TSDoc · CI green.