### PR TITLE
Add Expo Snack example to react-native-quick-preview

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23179,7 +23179,8 @@
   {
     "githubUrl": "https://github.com/Hashtagsmile/react-native-quick-preview/tree/main/packages/react-native-quick-preview",
     "examples": [
-      "https://github.com/Hashtagsmile/react-native-quick-preview/tree/main/apps/expo-quick-preview-example"
+      "https://github.com/Hashtagsmile/react-native-quick-preview/tree/main/apps/expo-quick-preview-example",
+      "https://snack.expo.dev/@oliver.at.sellpy/react-native-quick-preview"
     ],
     "images": [
       "https://raw.githubusercontent.com/Hashtagsmile/react-native-quick-preview/main/demo-feed.gif",


### PR DESCRIPTION
Follow-up to #2616. Adds a runnable in-browser Expo Snack to the `react-native-quick-preview` entry's `examples`.

The Snack is a product quick-look: long-press a product to peek its rating, description and stock, tap to open the full product page. It complements the existing example app already listed.

Snack: https://snack.expo.dev/@oliver.at.sellpy/react-native-quick-preview