### PR TITLE
Add Google Sign-In library with examples and config plugin support

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23301,6 +23301,7 @@
       "https://github.com/react-native-nitro-google-sign-in/google-signin/tree/HEAD/example",
       "https://github.com/react-native-nitro-google-sign-in/google-signin/tree/HEAD/example-expo"
     ],
+    "npmPkg": "react-native-nitro-google-signin",
     "configPlugin": true,
     "ios": true,
     "android": true

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23294,5 +23294,15 @@
     "examples": ["https://github.com/venky145/RN-VideoFeed/tree/main/VideoFeedSample"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/react-native-nitro-google-sign-in/google-signin",
+    "examples": [
+      "https://github.com/react-native-nitro-google-sign-in/google-signin/tree/HEAD/example",
+      "https://github.com/react-native-nitro-google-sign-in/google-signin/tree/HEAD/example-expo"
+    ],
+    "configPlugin": true,
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
## Summary
- Adds `@react-native-google-signin/google-signin` to the React Native Directory dataset

## Test plan
- [ ] Run `bun data:validate` locally
- [ ] Confirm the package appears in search on the directory site