### PR TITLE
add status filter for development tools

### DIFF
--- a/API.md
+++ b/API.md
@@ -25,13 +25,14 @@ Return a list of libraries from the dataset. Supports sorting, full-text search,
   - `search` - full-text search string (`relevance` sorting is used automatically when searching).
   - `owner` - filter by owner name.
   - `topic` - filter by topic or tag.
-  - Platform support filters (booleans): `ios`, `android`, `web`, `windows`, `macos`, `expoGo`, `fireos`, `horizon`, `tvos`, `visionos`, `vegaos`.
+  - Platform support filters (booleans): `ios`, `android`, `web`, `windows`, `macos`, `expoGo`, `fireos`, `harmony`, `horizon`, `tvos`, `visionos`, `vegaos`.
   - Feature filters (booleans): `hasExample`, `hasImage`, `hasTypes`, `hasNativeCode`, `configPlugin`.
   - Quality filters (booleans): `isMaintained`, `isPopular`, `wasRecentlyUpdated`.
   - Architecture filters (booleans): `newArchitecture`, `expoModule`, `nitroModule`, `turboModule`.
-  - Skip categories (booleans): `skipLibs`, `skipTools`, `skipTemplates`.
+  - Skip categories (booleans): `skipLibs`, `skipTools`.
   - Numeric filters: `minPopularity`, `minMonthlyDownloads`.
   - `nightlyProgram` - boolean flag for Nightly Program participation.
+  - `dev` - boolean flag to filter out Development Tools only.
   - `bookmarks` - when set, the server reads browser cookie bookmarks and returns only bookmarked libraries (see Notes below).
   - Pagination: `offset` (number, default `0`), `limit` (number, default `20`).
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
   "visionos": false,
   "expoGo": false,
   "fireos": false,
+  "harmony": false,
   "horizon": false,
   "vegaos": false,
   "newArchitecture": false,

--- a/components/Filters/helpers.ts
+++ b/components/Filters/helpers.ts
@@ -75,6 +75,10 @@ export const FILTER_STATUS: FilterParamsType[] = [
     param: 'wasRecentlyUpdated',
     title: 'Recently updated',
   },
+  {
+    param: 'dev',
+    title: 'Development Tool',
+  },
 ];
 
 export const FILTER_COMPATIBILITY: FilterParamsType[] = [

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -96,6 +96,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     newArchitecture: parsedQuery.newArchitecture,
     skipLibs: parsedQuery.skipLibs,
     skipTools: parsedQuery.skipTools,
+    dev: parsedQuery.dev,
     expoModule: parsedQuery.expoModule,
     nitroModule: parsedQuery.nitroModule,
     turboModule: parsedQuery.turboModule,

--- a/types/index.ts
+++ b/types/index.ts
@@ -33,6 +33,7 @@ export type Query = {
   harmony?: string;
   web?: string;
   windows?: string;
+  dev?: string;
   order?: QueryOrder;
   direction?: QueryOrderDirection;
   search?: string;

--- a/util/search.ts
+++ b/util/search.ts
@@ -119,6 +119,7 @@ export function handleFilterLibraries({
   minPopularity,
   minMonthlyDownloads,
   newArchitecture,
+  dev,
   skipLibs,
   skipTools,
   expoModule,
@@ -158,6 +159,10 @@ export function handleFilterLibraries({
     }
 
     if (skipTools && library.dev) {
+      return false;
+    }
+
+    if (dev === 'true' && !library.dev) {
       return false;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

So far we were only able to hide development tools from the list, no there is a way to only show them (filter dev tools) on the website and via API.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

<img width="1894" height="1605" alt="Screenshot 2026-07-10 160812" src="https://github.com/user-attachments/assets/b7191780-bd63-450b-8bb6-f1c6dea76ea6" />
