### PR TITLE
Add react-native-tour-guide

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23332,5 +23332,15 @@
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/himanshu-lal4/react-native-tour-guide",
+    "npmPkg": "@wrack/react-native-tour-guide",
+    "examples": ["https://github.com/himanshu-lal4/react-native-tour-guide/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds [react-native-tour-guide](https://github.com/himanshu-lal4/react-native-tour-guide) — a lightweight tour / walkthrough / coach-mark library for React Native.

- Auto shape-matching spotlight (matches each target's border radius)
- Smart auto-scroll so the target + tooltip both stay on screen
- Themeable tooltips, pulse animation, pause/resume, "show once" persistence
- Works with Expo (including Expo Go) and RN CLI — zero native dependencies (only react-native-svg)
- TypeScript, New Architecture (Fabric) ready

npm: https://www.npmjs.com/package/@wrack/react-native-tour-guide (~3.3k downloads/mo)

Entry appended at the end of `react-native-libraries.json` per the contributing guide; `false` fields skipped; validates against the schema.