### PR TITLE
Add react-native-liquid-glassmorphism

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23332,5 +23332,14 @@
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/himanshu-lal4/react-native-liquid-glassmorphism",
+    "npmPkg": "react-native-liquid-glassmorphism",
+    "examples": ["https://github.com/himanshu-lal4/react-native-liquid-glassmorphism/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true,
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
Adds **react-native-liquid-glassmorphism** — authentic Liquid Glass for React Native on both iOS and Android.

- iOS 26: Apple's native `UIGlassEffect` (with a `UIBlurEffect` fallback below 26)
- Android: a real-time AGSL refractive-lens shader (edge refraction, chromatic dispersion, mirrored edge reflection, Fresnel rim, tilt/touch specular) — real glass optics, not just blur
- Custom shapes (circle / squircle / polygon / points / arbitrary concave SVG path)
- Interactive touch + device-tilt specular
- Expo config plugin, New Architecture (Fabric) + old architecture, TypeScript

npm: https://www.npmjs.com/package/react-native-liquid-glassmorphism
Repo: https://github.com/himanshu-lal4/react-native-liquid-glassmorphism

Entry includes only accurate flags: `ios`, `android`, `newArchitecture`, `configPlugin`. It's a native module (needs a dev build / prebuild), so `expoGo` is intentionally omitted.