### PR TITLE
Add react-native-age-signals

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23357,9 +23357,7 @@
   {
     "githubUrl": "https://github.com/shtefanilie/react-native-age-signals",
     "npmPkg": "react-native-age-signals",
-    "examples": [
-      "https://github.com/shtefanilie/react-native-age-signals/tree/main/example"
-    ],
+    "examples": ["https://github.com/shtefanilie/react-native-age-signals/tree/main/example"],
     "newArchitecture": true,
     "ios": true,
     "android": true

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23353,5 +23353,15 @@
     "android": true,
     "newArchitecture": true,
     "configPlugin": true
+  },
+  {
+    "githubUrl": "https://github.com/shtefanilie/react-native-age-signals",
+    "npmPkg": "react-native-age-signals",
+    "examples": [
+      "https://github.com/shtefanilie/react-native-age-signals/tree/main/example"
+    ],
+    "newArchitecture": true,
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
## Add react-native-age-signals

Query the app store's knowledge of the current user's age bracket.

- **iOS** — Apple DeclaredAgeRange framework (iOS 26+)
- **Android** — Google Play Age Signals
- Built on Nitro Modules (JSI)
- npm: https://www.npmjs.com/package/react-native-age-signals
- GitHub: https://github.com/shtefanilie/react-native-age-signals