### PR TITLE
Markdown Renderer: fix links to release assets, allow tables to be centered

### DIFF
--- a/assets/check-data.json
+++ b/assets/check-data.json
@@ -8567,5 +8567,95 @@
   },
   "expo-paperkit": {
     "newArchitecture": "supported"
+  },
+  "execbro": {
+    "newArchitecture": "untested"
+  },
+  "rn-neo": {
+    "newArchitecture": "untested"
+  },
+  "@super-calendar/native": {
+    "newArchitecture": "untested"
+  },
+  "@the-sheet/the-sheet": {
+    "newArchitecture": "untested"
+  },
+  "@the-sheet/universe-portal": {
+    "newArchitecture": "untested"
+  },
+  "@the-sheet/embedded-stack-navigator": {
+    "newArchitecture": "untested"
+  },
+  "@the-sheet/flash-list-v2": {
+    "newArchitecture": "untested"
+  },
+  "react-native-reanimated-viewer": {
+    "newArchitecture": "untested"
+  },
+  "react-native-collapsible-fluid-tabs": {
+    "newArchitecture": "untested"
+  },
+  "react-native-splash-screen-newarch": {
+    "newArchitecture": "supported"
+  },
+  "uws-react-native": {
+    "newArchitecture": "new-arch-only"
+  },
+  "@ronradtke/react-native-markdown-display": {
+    "newArchitecture": "supported"
+  },
+  "@posthog/react-native-plugin": {
+    "newArchitecture": "supported"
+  },
+  "react-native-image-compression-kit": {
+    "newArchitecture": "supported"
+  },
+  "react-native-ometria": {
+    "newArchitecture": "supported"
+  },
+  "react-native-tenjin": {
+    "newArchitecture": "supported"
+  },
+  "rn-iso": {
+    "newArchitecture": "untested"
+  },
+  "vision-camera-ocr-plugin": {
+    "newArchitecture": "supported"
+  },
+  "react-native-vision-camera-face-detector": {
+    "newArchitecture": "supported"
+  },
+  "tapflow": {
+    "newArchitecture": "untested"
+  },
+  "react-native-quick-filter": {
+    "newArchitecture": "supported"
+  },
+  "react-native-quick-preview": {
+    "newArchitecture": "supported"
+  },
+  "rn-videofeed": {
+    "newArchitecture": "untested"
+  },
+  "@deskbtm/react-native-bottom-sheet": {
+    "newArchitecture": "supported"
+  },
+  "react-native-nitro-google-signin": {
+    "newArchitecture": "untested"
+  },
+  "react-native-turbo-preferences": {
+    "newArchitecture": "supported"
+  },
+  "react-native-nitro-vision-kit": {
+    "newArchitecture": "new-arch-only"
+  },
+  "@wrack/react-native-tour-guide": {
+    "newArchitecture": "supported"
+  },
+  "react-native-liquid-glassmorphism": {
+    "newArchitecture": "supported"
+  },
+  "react-native-age-signals": {
+    "newArchitecture": "supported"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "expo-font": "57.0.0",
         "next": "^16.2.10",
         "node-emoji": "^2.2.0",
-        "postcss": "^8.5.17",
+        "postcss": "^8.5.19",
         "react": "19.2.7",
         "react-content-loader": "^7.1.2",
         "react-dom": "19.2.7",
@@ -1653,7 +1653,7 @@
 
     "oxlint": ["oxlint@1.73.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.73.0", "@oxlint/binding-android-arm64": "1.73.0", "@oxlint/binding-darwin-arm64": "1.73.0", "@oxlint/binding-darwin-x64": "1.73.0", "@oxlint/binding-freebsd-x64": "1.73.0", "@oxlint/binding-linux-arm-gnueabihf": "1.73.0", "@oxlint/binding-linux-arm-musleabihf": "1.73.0", "@oxlint/binding-linux-arm64-gnu": "1.73.0", "@oxlint/binding-linux-arm64-musl": "1.73.0", "@oxlint/binding-linux-ppc64-gnu": "1.73.0", "@oxlint/binding-linux-riscv64-gnu": "1.73.0", "@oxlint/binding-linux-riscv64-musl": "1.73.0", "@oxlint/binding-linux-s390x-gnu": "1.73.0", "@oxlint/binding-linux-x64-gnu": "1.73.0", "@oxlint/binding-linux-x64-musl": "1.73.0", "@oxlint/binding-openharmony-arm64": "1.73.0", "@oxlint/binding-win32-arm64-msvc": "1.73.0", "@oxlint/binding-win32-ia32-msvc": "1.73.0", "@oxlint/binding-win32-x64-msvc": "1.73.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.24.0", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ=="],
 
-    "oxlint-plugin-react-doctor": ["oxlint-plugin-react-doctor@0.7.6", "", { "dependencies": { "@typescript-eslint/types": "^8.59.3", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "oxc-parser": "^0.138.0" } }, "sha512-oE01pROKCbxZ7mfHWXEZ27lw12ZWbWUe1p6OtgtRBtHWyNCqXi5MGYVsG7u3zlqG0i6k1UEYVvHrQvle2fJ1HQ=="],
+    "oxlint-plugin-react-doctor": ["oxlint-plugin-react-doctor@0.7.7", "", { "dependencies": { "@typescript-eslint/types": "^8.59.3", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "oxc-parser": "^0.138.0" } }, "sha512-OMl/8k3rcxTSyMJWUL/pdq/ZZKFtv1F4kyM+AWYsj/YYaL/nftL/idrJOxyd2CuFa5Nrbz2DlK3QFRej1uwQ/Q=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@0.24.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.24.0", "@oxlint-tsgolint/darwin-x64": "0.24.0", "@oxlint-tsgolint/linux-arm64": "0.24.0", "@oxlint-tsgolint/linux-x64": "0.24.0", "@oxlint-tsgolint/win32-arm64": "0.24.0", "@oxlint-tsgolint/win32-x64": "0.24.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw=="],
 
@@ -1691,7 +1691,7 @@
 
     "pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
-    "postcss": ["postcss@8.5.17", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w=="],
+    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 
     "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
 

--- a/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
+++ b/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
@@ -110,10 +110,12 @@ export default function MarkdownRenderer({ data, repoUrl, linkableHeaders = true
           }
           return null;
         },
-        table: ({ children }) => {
+        table: ({ children, node }) => {
           return (
-            // @ts-expect-error dataSet is a valid RNW prop
-            <View dataSet={{ tableWrapper: true }}>
+            <View
+              // @ts-expect-error dataSet is a valid RNW prop
+              dataSet={{ tableWrapper: true }}
+              style={node.properties.align === 'center' ? tw`mx-auto` : undefined}>
               <table>{children}</table>
             </View>
           );

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "expo-font": "57.0.0",
     "next": "^16.2.10",
     "node-emoji": "^2.2.0",
-    "postcss": "^8.5.17",
+    "postcss": "^8.5.19",
     "react": "19.2.7",
     "react-content-loader": "^7.1.2",
     "react-dom": "19.2.7",

--- a/util/getReadmeAssetUrl.ts
+++ b/util/getReadmeAssetUrl.ts
@@ -2,7 +2,10 @@ const FILE_WITH_EXTENSION_REGEX = /\/[^/?#]+\.[^/?#]+(?=(?:\?|#|$))/i;
 
 export function getReadmeAssetURL(src: string, githubUrl: string, defaultBranch = 'main') {
   const isGitHubAssetURL =
-    src.includes('github.com') && !src.endsWith('badge.svg') && !src.includes('user-attachments');
+    src.includes('github.com') &&
+    !src.endsWith('badge.svg') &&
+    !src.includes('user-attachments') &&
+    !src.includes('releases/download');
 
   if (src.startsWith('http') && (!isGitHubAssetURL || !FILE_WITH_EXTENSION_REGEX.test(src))) {
     return src;


### PR DESCRIPTION
# 📝 Why & how

Summary of changes:
* Markdown Renderer: fix links to release assets
* Markdown Renderer: allow tables to be centered
* update local data
* bump dependencies

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

<img width="1345" height="1587" alt="Screenshot 2026-07-13 155536" src="https://github.com/user-attachments/assets/8f09e8a1-89a3-4826-a0fa-a9d84a2521c7" />
