### PR TITLE
Add @codemagic/react-native-patch to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23385,14 +23385,14 @@
     "ios": true,
     "android": true
   },
-{
-  "githubUrl": "https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/client",
-  "npmPkg": "@codemagic/react-native-patch",
-  "examples": [
-    "https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/examples/on-device-demo"
-  ],
-  "ios": true,
-  "android": true,
-  "configPlugin": true
-}
+  {
+    "githubUrl": "https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/client",
+    "npmPkg": "@codemagic/react-native-patch",
+    "examples": [
+      "https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/examples/on-device-demo"
+    ],
+    "ios": true,
+    "android": true,
+    "configPlugin": true
+  }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23384,5 +23384,15 @@
     "newArchitecture": true,
     "ios": true,
     "android": true
-  }
+  },
+{
+  "githubUrl": "https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/client",
+  "npmPkg": "@codemagic/react-native-patch",
+  "examples": [
+    "https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/examples/on-device-demo"
+  ],
+  "ios": true,
+  "android": true,
+  "configPlugin": true
+}
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `@codemagic/react-native-patch` (https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/client) to the directory.

React Native / Expo client SDK for Codemagic Patch (over-the-air JS and asset updates).

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
