### PR TITLE
Mark @bsky.app/expo-image-crop-tool as New Architecture compatible

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16040,7 +16040,8 @@
     "npmPkg": "@bsky.app/expo-image-crop-tool",
     "examples": ["https://github.com/bluesky-social/expo-image-crop-tool/tree/main/example"],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/echowaves/expo-cached-image",


### PR DESCRIPTION
# 📝 Why & how

React Native Directory currently reports `@bsky.app/expo-image-crop-tool` as untested because automatic detection does not recognize its Expo Modules API implementation. The package’s own checked-in example explicitly enables the New Architecture (`newArchEnabled: true`) on Expo 54 / React Native 0.81, and the module compiles successfully for both iOS and Android with New Architecture enabled.

This adds only `"newArchitecture": true` to the existing directory entry, as recommended when automatic detection misses a compatible package.

# ✅ Verification

- `bun data:test`
- `bun data:validate`
- `GITHUB_TOKEN=… bun ci:validate`
- `bun lint`

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**
- [x] Documented how the status was verified.
- [x] Described the metadata-only fix.