### PR TITLE
Add @alimirzayev/react-native-background-timer

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23410,5 +23410,17 @@
     "expoGo": true,
     "newArchitecture": true,
     "vegaos": true
+  },
+  {
+    "githubUrl": "https://github.com/alimirzayev/react-native-background-timer",
+    "npmPkg": "@alimirzayev/react-native-background-timer",
+    "examples": [
+      "https://github.com/alimirzayev/react-native-background-timer/tree/main/examples/bare",
+      "https://github.com/alimirzayev/react-native-background-timer/tree/main/examples/expo"
+    ],
+    "newArchitecture": "new-arch-only",
+    "ios": true,
+    "android": true,
+    "web": true
   }
 ]


### PR DESCRIPTION
# Why & how

This PR adds `@alimirzayev/react-native-background-timer` to React Native Directory.

The package provides background-aware timers for Android and iOS using React Native's New Architecture, with a foreground-compatible web fallback. It supports Android, iOS, and web, and requires a development build when used with Expo.

# Checklist

- [x] Published on npm
- [x] Added at the end of `react-native-libraries.json`
- [x] Included bare React Native and Expo example projects
- [x] Marked as New Architecture only
- [x] JSON formatting, schema, and duplicate validation pass
