### PR TITLE
Add react-native-app-inspector to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23410,5 +23410,11 @@
     "expoGo": true,
     "newArchitecture": true,
     "vegaos": true
+  },
+  {
+    "githubUrl": "https://github.com/phaelor/react-native-app-inspector",
+    "examples": ["https://github.com/phaelor/react-native-app-inspector/tree/HEAD/example"],
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `react-native-app-inspector` (https://github.com/phaelor/react-native-app-inspector) package to the directory.

> [!NOTE]
> This is an automatic submission created via `rn-directory` CLI.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
