### PR TITLE
MarkdownContentBox: always fallback to shell highlight

### DIFF
--- a/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
+++ b/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
@@ -153,19 +153,12 @@ export default function MarkdownRenderer({ data, repoUrl, linkableHeaders = true
         ),
         pre: ({ children }: any) => {
           const langClass = children?.props?.className;
-          if (langClass) {
-            return (
-              <MarkdownCodeBlock
-                code={children.props.children}
-                theme={(tw.prefixMatch('dark') ? rndDark : rndLight) as Theme}
-                lang={langClass ? (langClass.split('-')[1] ?? 'sh').toLowerCase() : 'sh'}
-              />
-            );
-          }
           return (
-            <div style={tw`relative my-2`} className="readme-code-block">
-              <pre className="shiki">{children}</pre>
-            </div>
+            <MarkdownCodeBlock
+              code={children.props.children}
+              theme={(tw.prefixMatch('dark') ? rndDark : rndLight) as Theme}
+              lang={langClass ? (langClass.split('-')[1] ?? 'sh').toLowerCase() : 'sh'}
+            />
           );
         },
         blockquote: ({ children }: any) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Fixes: #2654

Always fallback to shell highlight in MarkdownContentBox when rendering code blocks, to improve readability and avoid skipping comment lines.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

<img width="1331" height="424" alt="Screenshot 2026-07-16 115048" src="https://github.com/user-attachments/assets/a29388f4-9ce6-477a-a0ed-704df64fe0b6" />
