### PR TITLE
Add react-native-device-risk-signals

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23480,5 +23480,17 @@
     "githubUrl": "https://github.com/expo/expo/tree/main/packages/expo-widgets",
     "newArchitecture": true,
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/AfanasievN/react-native-device-risk-signals",
+    "examples": [
+      "https://github.com/AfanasievN/react-native-device-risk-signals/tree/main/example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/AfanasievN/react-native-device-risk-signals/main/docs/images/signal-bench-results.png"
+    ],
+    "newArchitecture": "new-arch-only",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
Adds react-native-device-risk-signals, a privacy-conscious device risk signal library for React Native.\n\nThe entry includes:\n- Android and iOS support\n- New Architecture-only compatibility\n- A runnable example application\n- A screenshot of the signal inspector\n\nValidation: the directory JSON passes the repository schema via ajv-cli.