### PR TITLE
Add react-native-edge-glow library details

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,5 +1,17 @@
 [
   {
+  "githubUrl": "https://github.com/aravi365/react-native-edge-glow",
+  "npmPkg": "react-native-edge-glow",
+  "images": [
+    "https://raw.githubusercontent.com/aravi365/react-native-edge-glow/main/assets/edge-glow-ios.gif",
+    "https://raw.githubusercontent.com/aravi365/react-native-edge-glow/main/assets/edge-glow-android.gif",
+    "https://raw.githubusercontent.com/aravi365/react-native-edge-glow/main/assets/edge-glow-siri.gif"
+  ],
+  "ios": true,
+  "android": true,
+  "newArchitecture": true
+},
+  {
     "githubUrl": "https://github.com/mowispace/react-native-logs",
     "ios": true,
     "android": true,


### PR DESCRIPTION
# 📝 Why & how

Adds a new library: **react-native-edge-glow** — a Siri/Gemini-style animated glow around the screen edges. It runs the animation on the UI thread via Reanimated, reads the device's real display corner radius on Android 12+ (via the public WindowInsets API), and ships with presets, a breathing pulse, and reduce-motion support. Dependencies are only `react-native-svg` + `react-native-reanimated` (no Skia).

- npm: https://www.npmjs.com/package/react-native-edge-glow
- Repo: https://github.com/aravi365/react-native-edge-glow

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**