### PR TITLE
Add react-native-edge-glow

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23502,5 +23502,17 @@
     "web": true,
     "expoGo": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/aravi365/react-native-edge-glow",
+    "npmPkg": "react-native-edge-glow",
+    "images": [
+      "https://raw.githubusercontent.com/aravi365/react-native-edge-glow/main/assets/edge-glow-ios.gif",
+      "https://raw.githubusercontent.com/aravi365/react-native-edge-glow/main/assets/edge-glow-android.gif",
+      "https://raw.githubusercontent.com/aravi365/react-native-edge-glow/main/assets/edge-glow-siri.gif"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds **react-native-edge-glow** — a Siri/Gemini-style animated edge glow (UI-thread via Reanimated, reads the real display corner radius on Android 12+). Only depends on `react-native-svg` + `react-native-reanimated`.

Recreated from #2661 per maintainer feedback:
- Entry moved to the **end** of the list (for "Recently added" order).
- npm downloads data is now populated, so the earlier npm-API failure won't recur.
- Verified locally against `.oxfmtrc.json` — `oxfmt --check` passes and JSON is valid.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**