### PR TITLE
Add New Architecture metadata for @siteed/audio-studio

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -22044,7 +22044,8 @@
     ],
     "ios": true,
     "android": true,
-    "web": true
+    "web": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/ahmeterenodaci/rn-mlkit-ocr",


### PR DESCRIPTION
# 📝 Why & how

`@siteed/audio-studio@3.2.1` is implemented with Expo Modules API on both iOS and Android (`Module` / `ModuleDefinition`) and is consumed through `requireNativeModule('AudioStudio')`.

The package builds successfully with React Native 0.86 and New Architecture enabled in an Expo SDK 57 application on both Android Release and iOS Debug/Release. React Native Directory currently lacks the explicit `newArchitecture` metadata, so Expo Doctor reports it as untested.

This PR only adds `newArchitecture: true` to the existing package entry. It does not claim complete device-level recording behavior coverage.

Verification:

- `bun data:test`
- `bun data:validate`
- `bun lint`

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**
- [x] Documented how the issue was replicated with Expo Doctor.
- [x] Explained the one-line metadata fix.
- [x] Described how to verify the change.