### PR TITLE
Add image compression kit demo screenshots

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23239,6 +23239,10 @@
     "examples": [
       "https://github.com/GGULBAE/react-native-image-compression-kit/tree/master/example"
     ],
+    "images": [
+      "https://raw.githubusercontent.com/GGULBAE/react-native-image-compression-kit/master/website/public/demo/android/screen.png",
+      "https://raw.githubusercontent.com/GGULBAE/react-native-image-compression-kit/master/website/public/demo/ios/screen.png"
+    ],
     "ios": true,
     "android": true,
     "newArchitecture": true


### PR DESCRIPTION
## What changed

Adds the verified Android and iOS demo screenshots to the existing `react-native-image-compression-kit` directory entry.

## Why

The package entry already exposes its example app and verified platform support. These images make the native before/after demo visible from React Native Directory without changing compatibility metadata.

## Validation

- `bun data:test`
- `bun data:validate`
- `bun ci:validate`
- `bun lint`
- both raw image URLs return HTTP 200 with `image/png`
