### PR TITLE
Fix Overview crash on hrefless README anchors

### DIFF
--- a/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
+++ b/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
@@ -87,7 +87,7 @@ export default function MarkdownRenderer({ data, repoUrl, linkableHeaders = true
         br: () => null,
         hr: () => null,
         a: (props: any) => {
-          if (props.href.startsWith('#')) {
+          if (props.href?.startsWith('#')) {
             return <A {...props} target="_self" />;
           } else if (props.href && !props.href.startsWith('//')) {
             if (!props.href.startsWith('http')) {


### PR DESCRIPTION
## Summary

Fixes #2670. The package Overview page throws a client-side exception and renders the error page when a README contains a hrefless anchor (e.g. `<a name="section"></a>`).

## Cause

In `MarkdownRenderer.tsx`, the `a` handler starts with:

```ts
if (props.href.startsWith('#')) {
```

`rehype-raw` parses `<a name="...">` into an anchor node with no `href`, so `props.href` is `undefined` and `.startsWith()` throws, which takes down the whole Overview render.

## Fix

```ts
if (props.href?.startsWith('#')) {
```

The handler already ends with a `return <span>{props.children}</span>` fallback, so with optional chaining a hrefless anchor falls through to that fallback instead of crashing. One-character change, no behavior change for anchors that have an `href`.

## Reproduction

Live example before the fix: https://reactnative.directory/package/tapflow (Overview tab crashes; Code / Versions / Score are fine). Console:

```text
TypeError: Cannot read properties of undefined (reading 'startsWith')
  at MarkdownRenderer.tsx:90
```

Also reproduced the parse with a standard `remark -> remark-rehype (allowDangerousHtml) -> rehype-raw` pipeline: a `<a name>` anchor yields one `<a>` node without an `href`, which is what hits the unguarded `.startsWith`.