### PR TITLE
visual tweaks for HTML rendering in MD files, handle video loading error

### DIFF
--- a/components/Package/MarkdownContentBox/MarkdownVideoPlayer/index.tsx
+++ b/components/Package/MarkdownContentBox/MarkdownVideoPlayer/index.tsx
@@ -4,8 +4,11 @@ import '@videojs/react/video/minimal-skin.css';
 
 import { Container } from '@videojs/react';
 import { Video } from '@videojs/react/video';
-import { type VideoHTMLAttributes } from 'react';
+import { useState, type VideoHTMLAttributes } from 'react';
 import { type Style } from 'twrnc';
+
+import { P } from '~/common/styleguide';
+import tw from '~/util/tailwind';
 
 import { InlinePlayer } from './InlinePlayer';
 import { MarkdownVideoPlayerUI } from './MarkdownVideoPlayerUI';
@@ -16,13 +19,28 @@ type Props = {
 };
 
 export default function MarkdownVideoPlayer({ src, style }: Props) {
+  const [hasError, setHasError] = useState(false);
   return (
     <InlinePlayer.Provider>
       <Container
         className="media-minimal-skin media-minimal-skin--video relative mt-3 max-h-[592px] max-w-full"
         style={style}>
-        <Video src={src} playsInline muted className="max-h-[592px]" />
-        <MarkdownVideoPlayerUI />
+        {hasError ? (
+          <P style={tw`text-center text-sm font-light leading-[150px] text-secondary`}>
+            Unable to load video source
+          </P>
+        ) : (
+          <>
+            <Video
+              src={src}
+              playsInline
+              muted
+              className="max-h-[592px]"
+              onError={() => setHasError(true)}
+            />
+            <MarkdownVideoPlayerUI />
+          </>
+        )}
       </Container>
     </InlinePlayer.Provider>
   );

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -415,6 +415,10 @@ select {
     margin-bottom: 0;
   }
 
+  div + div {
+    margin-top: 12px;
+  }
+
   section {
     margin-top: 18px;
   }
@@ -456,6 +460,18 @@ select {
 
     &[align='center'] img {
       margin: 0 auto;
+    }
+
+    [align='center'] & {
+      justify-content: center;
+      text-align: center;
+
+      &:hover {
+        a[href^='#'] {
+          position: absolute;
+          top: -8px;
+        }
+      }
     }
 
     + div {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Spotted few rendering issue on https://reactnative.directory/package/tapflow package page.

Summary of changes:
* center heading is parent has `align="center"` property (ideally we should propagate the property to children, but is a simple solution for now)
* adjust the hash link button in centered headers to avoid content shift
* handle Markdown video elements loading error
* add spacing between HTML `div` when they are used in Markdown 

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

<img width="1323" height="1163" alt="Screenshot 2026-07-20 190511" src="https://github.com/user-attachments/assets/81d787c8-b95c-447e-bd05-7a5742e03f87" />

