### PR TITLE
Add react-native-nitro-godot

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,10 +1,5 @@
 [
   {
-    "githubUrl": "https://github.com/hung-yueh/react-native-nitro-godot",
-    "ios": true,
-    "android": true
-  },
-  {
     "githubUrl": "https://github.com/mowispace/react-native-logs",
     "ios": true,
     "android": true,
@@ -23550,5 +23545,14 @@
     "ios": true,
     "android": true,
     "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/hung-yueh/react-native-nitro-godot",
+    "examples": [
+      "https://github.com/hung-yueh/react-native-nitro-godot/tree/main/examples/dungeon-dash"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,5 +1,10 @@
 [
   {
+    "githubUrl": "https://github.com/hung-yueh/react-native-nitro-godot",
+    "ios": true,
+    "android": true
+  },
+  {
     "githubUrl": "https://github.com/mowispace/react-native-logs",
     "ios": true,
     "android": true,


### PR DESCRIPTION
Adds [`react-native-nitro-godot`](https://github.com/hung-yueh/react-native-nitro-godot) — embeds the Godot Engine as a native rendering surface via Nitro Modules (zero-overhead JSI, pure C++), for iOS and Android.

- npm: https://www.npmjs.com/package/react-native-nitro-godot
- Repo: https://github.com/hung-yueh/react-native-nitro-godot
- Platforms: iOS, Android

Entry validates against `react-native-libraries.schema.json` (githubUrl + ios/android).