### PR TITLE
Add react-native-permission-gate

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23608,5 +23608,12 @@
     "android": true,
     "newArchitecture": true,
     "configPlugin": true
+  },
+  {
+    "githubUrl": "https://github.com/cengizemre/react-native-permission-gate",
+    "examples": ["https://github.com/cengizemre/react-native-permission-gate/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds [react-native-permission-gate](https://github.com/cengizemre/react-native-permission-gate) headless permission-flow orchestration for React Native: a state-machine hook (`usePermission` / `usePermissions`), rationale gating, blocked → Settings routing, focus re-validation, and app-wide native-prompt serialization. Built on top of `react-native-permissions`, fully typed, adapter-agnostic core with unit tests. Published on npm as [`react-native-permission-gate`](https://www.npmjs.com/package/react-native-permission-gate) (MIT).