### PR TITLE
add unique `alt` description for package images thumbnails

### DIFF
--- a/components/Library/Thumbnail.tsx
+++ b/components/Library/Thumbnail.tsx
@@ -7,11 +7,12 @@ import tw from '~/util/tailwind';
 
 type Props = {
   url: string;
+  alt: string;
 };
 
 const GITHUB_PREVIEW_MIN_WIDTH = 640;
 
-function Thumbnail({ url }: Props) {
+function Thumbnail({ url, alt }: Props) {
   const { width, height } = useWindowDimensions();
 
   const [isLoaded, setLoaded] = useState(false);
@@ -56,7 +57,7 @@ function Thumbnail({ url }: Props) {
             <img
               src={url}
               onLoad={() => setLoaded(true)}
-              alt=""
+              alt={alt}
               style={{
                 ...tw`rounded`,
                 maxWidth: maxPreviewImageWidth,

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -125,8 +125,8 @@ function Library({
         </View>
         {!skipMetadata && Platform.OS === 'web' && library.images && library.images.length > 0 && (
           <View style={tw`mt-2 flex-row flex-wrap items-center gap-x-0.5`}>
-            {library.images.map(image => (
-              <Thumbnail key={image} url={image} />
+            {library.images.map((image, i) => (
+              <Thumbnail key={image} url={image} alt={`${library.npmPkg} screenshot ${i + 1}`} />
             ))}
           </View>
         )}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Supersedes #2432 due to lack of activity.

Add unique `alt` description for the package images thumbnails.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.
