### PR TITLE
Add @softwhere-uz/react-native-myid

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23561,5 +23561,14 @@
     "examples": ["https://github.com/Doko-Demo-Doa/react-native-pdf-editor/tree/HEAD/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/softwhere-uz/react-native-myid",
+    "npmPkg": "@softwhere-uz/react-native-myid",
+    "examples": ["https://github.com/softwhere-uz/react-native-myid/tree/HEAD/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true,
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
Adds [@softwhere-uz/react-native-myid](https://github.com/softwhere-uz/react-native-myid) — a wrapper for MyID, Uzbekistan's national biometric eKYC (face liveness) SDK, used by banks/fintech for identity verification.

- npm: https://www.npmjs.com/package/@softwhere-uz/react-native-myid (published with provenance)
- Ships its own Expo config plugin (`configPlugin: true`) — static frameworks, camera permission, iOS privacy manifest, Android Maven repo
- New Architecture: Expo Modules API; tested on a physical device with RN 0.86
- `expoGo` intentionally omitted (native module — requires a development build)
- Example app included in the repo

Note: the directory currently has no MyID/eKYC libraries. The unscoped npm package `react-native-myid` is a different, unmaintained project — hence the explicit `npmPkg` field.