### PR TITLE
temporaryli introduce simpler package check query

### DIFF
--- a/scripts/fetch-github-data.ts
+++ b/scripts/fetch-github-data.ts
@@ -1,5 +1,6 @@
 import { config } from 'dotenv';
 
+import GitHubRepositoryCheckQuery from '~/scripts/queries/GitHubRepositoryCheckQuery';
 import { type LibraryLicenseType, type LibraryType } from '~/types';
 import detectModuleType from '~/util/github/detectModuleType';
 import hasConfigPlugin from '~/util/github/hasConfigPlugin';
@@ -65,7 +66,10 @@ export async function fetchGithubRateLimit() {
   return {};
 }
 
-export async function fetchGithubData(data: LibraryType, retries = 2): Promise<LibraryType> {
+export async function fetchGithubData(
+  data: LibraryType,
+  { retries = 2, check = false } = {}
+): Promise<LibraryType> {
   if (retries < 0) {
     console.error(`[GH] ERROR fetching ${data.githubUrl} - OUT OF RETRIES`);
     return data;
@@ -76,14 +80,17 @@ export async function fetchGithubData(data: LibraryType, retries = 2): Promise<L
     const fullName = `${repoOwner}/${repoName}`;
     const branch = branchName ?? 'HEAD';
 
-    const result = await makeGraphqlQuery(GitHubRepositoryQuery, {
-      repoOwner,
-      repoName,
-      packagePath,
-      packageFilesPath: packagePath === '.' ? `${branch}:` : `${branch}:${packagePath}`,
-      packageJsonPath: `${branch}:${packagePath === '.' ? '' : `${packagePath}/`}package.json`,
-      fetchRoot: packagePath !== '.',
-    });
+    const result = await makeGraphqlQuery(
+      check ? GitHubRepositoryCheckQuery : GitHubRepositoryQuery,
+      {
+        repoOwner,
+        repoName,
+        packagePath,
+        packageFilesPath: packagePath === '.' ? `${branch}:` : `${branch}:${packagePath}`,
+        packageJsonPath: `${branch}:${packagePath === '.' ? '' : `${packagePath}/`}package.json`,
+        fetchRoot: packagePath !== '.',
+      }
+    );
 
     if (result.errors) {
       if (result.errors[0].type === 'NOT_FOUND') {
@@ -98,17 +105,19 @@ export async function fetchGithubData(data: LibraryType, retries = 2): Promise<L
         console.warn(`[GH] Data fetch error for ${fullName}`, result.errors);
       }
 
-      console.log(`[GH] Retrying fetch for ${data.githubUrl} due to error result`);
+      console.log(
+        `[GH] Retrying fetch for ${data.githubUrl} due to error result (attempts left: ${retries})`
+      );
       await sleep(REQUEST_SLEEP, REQUEST_SLEEP * 2);
-      return await fetchGithubData(data, retries - 1);
+      return await fetchGithubData(data, { retries: retries - 1, check });
     }
 
     if (!result?.data?.repository) {
       console.log(
-        `[GH] Retrying fetch for ${data.githubUrl} due to ${result?.message?.toLowerCase() ?? 'missing data'} (status: ${result?.status ?? 'Unknown'})`
+        `[GH] Retrying fetch for ${data.githubUrl} due to ${result?.message?.toLowerCase() ?? 'missing data'} (status: ${result?.status ?? 'Unknown'}, attempts left: ${retries})`
       );
       await sleep(REQUEST_SLEEP, REQUEST_SLEEP * 2);
-      return await fetchGithubData(data, retries - 1);
+      return await fetchGithubData(data, { retries: retries - 1, check });
     }
 
     const github = createRepoDataWithResponse(result.data.repository, isMonorepo);
@@ -118,9 +127,12 @@ export async function fetchGithubData(data: LibraryType, retries = 2): Promise<L
       github,
     };
   } catch (error) {
-    console.log(`[GH] Retrying fetch for ${data.githubUrl} due to an error`, error);
+    console.log(
+      `[GH] Retrying fetch for ${data.githubUrl} due to an error (attempts left: ${retries})`,
+      error
+    );
     await sleep(REQUEST_SLEEP, REQUEST_SLEEP * 2);
-    return await fetchGithubData(data, retries - 1);
+    return await fetchGithubData(data, { retries: retries - 1, check });
   }
 }
 
@@ -207,10 +219,10 @@ function createRepoDataWithResponse(json: any, monorepo: boolean): LibraryType['
       updatedAt: lastCommitAt,
       createdAt: json.createdAt,
       pushedAt: lastCommitAt,
-      forks: json.forks.totalCount,
-      issues: json.issues.totalCount,
-      subscribers: json.watchers.totalCount,
-      stars: json.stargazers.totalCount,
+      forks: json?.forks?.totalCount ?? -1,
+      issues: json?.issues?.totalCount ?? -1,
+      subscribers: json?.watchers?.totalCount ?? -1,
+      stars: json?.stargazers?.totalCount ?? -1,
       dependencies: json.dependenciesCount,
     },
     name: json.name,

--- a/scripts/queries/GitHubRepositoryCheckQuery.ts
+++ b/scripts/queries/GitHubRepositoryCheckQuery.ts
@@ -1,0 +1,92 @@
+const GitHubRepositoryCheckQuery = `
+  query (
+    $repoOwner: String!,
+    $repoName: String!,
+    $packagePath: String = ".",
+    $packageFilesPath: String = "HEAD:.",
+    $packageJsonPath: String = "HEAD:package.json",
+    $fetchRoot: Boolean = false
+  ) {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+    repository(owner: $repoOwner, name: $repoName) {
+      hasDiscussionsEnabled
+      hasIssuesEnabled
+      hasProjectsEnabled
+      hasSponsorshipsEnabled
+      hasWikiEnabled
+      hasVulnerabilityAlertsEnabled
+      description
+      createdAt
+      pushedAt
+      updatedAt
+      homepageUrl
+      url
+      mirrorUrl
+      name
+      nameWithOwner
+      isArchived
+      isMirror
+      isPrivate
+      licenseInfo {
+        key
+        name
+        spdxId
+        url
+        id
+      }
+      repositoryTopics(first: 15) {
+        nodes {
+          topic {
+            name
+          }
+        }
+      }
+      defaultBranchRef {
+        target {
+          ... on Commit {
+            id
+            history(path: $packagePath, first: 1) {
+              nodes {
+                committedDate
+                message
+              }
+            }
+          }
+        }
+      }
+      packageJson:object(expression: $packageJsonPath) {
+        ... on Blob {
+          text
+        }
+      }
+      files: object(expression: $packageFilesPath) {
+        ... on Tree {
+          entries {
+            name
+            type
+          }
+        }
+      }
+      rootPackageJson: object(expression: "HEAD:package.json") @include(if: $fetchRoot) {
+        ... on Blob {
+          text
+        }
+      }
+      rootFiles: object(expression: "HEAD:") @include(if: $fetchRoot) {
+        ... on Tree {
+          entries {
+            name
+            type
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default GitHubRepositoryCheckQuery;

--- a/scripts/validate-new-entries.ts
+++ b/scripts/validate-new-entries.ts
@@ -54,7 +54,7 @@ for (let i = 0; i < modifiedEntries.length; i += BATCH_SIZE) {
       continue;
     }
 
-    const entryWithGitHubData = await fetchGithubData(entryWithNpmData);
+    const entryWithGitHubData = await fetchGithubData(entryWithNpmData, { check: true });
 
     if (!entryWithGitHubData.github) {
       console.error(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

For some reason GitHub started to restrict fetching repository stargazers count, which is not reflected in the docs:
* https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-metadata

Might be an unintended side effect of some recent changes, so for now we can introduce a simpler package check query to stop blocking the new entry additions. This approach was working for me locally, but let's see how CI behaves.

Additionally, I have made small changes to the `fetchGithubData` opts and log messages.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.
