### PR TITLE
add @thoughtbot/react-native-social-auth to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23602,7 +23602,7 @@
     "npmPkg": "@thoughtbot/react-native-social-auth",
     "examples": ["https://github.com/thoughtbot/react-native-social-auth/tree/main/example"],
     "images": [
-      "https://github.com/thoughtbot/react-native-social-auth/blob/main/example/assets/607211820-e04101f3-30b1-49f9-a249-562496f43061-ezgif.com-video-to-gif-converter.gif"
+      "https://raw.githubusercontent.com/thoughtbot/react-native-social-auth/refs/heads/main/example/assets/607211820-e04101f3-30b1-49f9-a249-562496f43061-ezgif.com-video-to-gif-converter.gif"
     ],
     "ios": true,
     "android": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23600,9 +23600,7 @@
   {
     "githubUrl": "https://github.com/thoughtbot/react-native-social-auth",
     "npmPkg": "@thoughtbot/react-native-social-auth",
-    "examples": [
-      "https://github.com/thoughtbot/react-native-social-auth/tree/main/example"
-    ],
+    "examples": ["https://github.com/thoughtbot/react-native-social-auth/tree/main/example"],
     "images": [
       "https://github.com/thoughtbot/react-native-social-auth/blob/main/example/assets/607211820-e04101f3-30b1-49f9-a249-562496f43061-ezgif.com-video-to-gif-converter.gif"
     ],

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23596,5 +23596,19 @@
     "web": true,
     "macos": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/thoughtbot/react-native-social-auth",
+    "npmPkg": "@thoughtbot/react-native-social-auth",
+    "examples": [
+      "https://github.com/thoughtbot/react-native-social-auth/tree/main/example"
+    ],
+    "images": [
+      "https://github.com/thoughtbot/react-native-social-auth/blob/main/example/assets/607211820-e04101f3-30b1-49f9-a249-562496f43061-ezgif.com-video-to-gif-converter.gif"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true,
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
# Summary

Adds [`@thoughtbot/react-native-social-auth`](https://github.com/thoughtbot/react-native-social-auth) to the React Native Directory so it can be discovered by users.

The new directory entry includes:

- The GitHub repository and npm package
- A link to the example application
- A preview image
- Support metadata for iOS and Android
- React Native New Architecture support
- Expo config plugin support

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
