### PR TITLE
Add @pachun/reanimated-worklet-capture-guard

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23608,5 +23608,10 @@
     "android": true,
     "newArchitecture": true,
     "configPlugin": true
+  },
+  {
+    "githubUrl": "https://github.com/pachun/reanimated-worklet-capture-guard",
+    "npmPkg": "@pachun/reanimated-worklet-capture-guard",
+    "dev": true
   }
 ]


### PR DESCRIPTION
Adds `@pachun/reanimated-worklet-capture-guard`, a development tool that fails your Jest tests when a Reanimated worklet captures a React element — a capture that crashes on device with `[Worklets] Cannot copy value of type 'FiberNode'` but passes CI, because the Reanimated Jest mock does not serialize worklets.

Marked `dev: true` as it is only part of the development process (a Babel plugin plus a Jest setup file); it ships no runtime code.

- npm: https://www.npmjs.com/package/@pachun/reanimated-worklet-capture-guard
- repo: https://github.com/pachun/reanimated-worklet-capture-guard