### PR TITLE
throw on API limit reached, stop refetching when FORBIDDEN

### DIFF
--- a/scripts/fetch-github-data.ts
+++ b/scripts/fetch-github-data.ts
@@ -60,7 +60,8 @@ export async function fetchGithubRateLimit() {
   }
 
   if (result.errors) {
-    console.log('[GH] GraphQL API error:', result.errors);
+    console.error('[GH] GraphQL API error:', result.errors);
+    throw new Error('GitHub rate limit exceeded, aborting!');
   }
 
   return {};
@@ -103,6 +104,9 @@ export async function fetchGithubData(
         }
       } else {
         console.warn(`[GH] Data fetch error for ${fullName}`, result.errors);
+        if (result.errors.type === 'FORBIDDEN') {
+          return await fetchGithubData(data, { retries: -1, check });
+        }
       }
 
       console.log(

--- a/scripts/fetch-github-data.ts
+++ b/scripts/fetch-github-data.ts
@@ -94,7 +94,7 @@ export async function fetchGithubData(
     );
 
     if (result.errors) {
-      if (result.errors[0].type === 'NOT_FOUND') {
+      if (result.errors?.type === 'NOT_FOUND' || result.errors[0]?.type === 'NOT_FOUND') {
         const newUrl = await getUpdatedUrl(url);
         if (newUrl !== url) {
           console.warn(`[GH] Repository ${fullName} has moved to ${newUrl}`);
@@ -104,7 +104,7 @@ export async function fetchGithubData(
         }
       } else {
         console.warn(`[GH] Data fetch error for ${fullName}`, result.errors);
-        if (result.errors.type === 'FORBIDDEN') {
+        if (result.errors?.type === 'FORBIDDEN' || result.errors[0]?.type === 'FORBIDDEN') {
           return await fetchGithubData(data, { retries: -1, check });
         }
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Immediately throw on API limit reached, stop refetching when result type is set to `FORBIDDEN` to bail out fetching and reduce deployment time.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.
