### PR TITLE
Add @d3sm/kalendar

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23621,5 +23621,12 @@
     "dev": true,
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/d3sm/kalendar",
+    "npmPkg": "@d3sm/kalendar",
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [@d3sm/kalendar](https://github.com/d3sm/kalendar) — a native React Native calendar with a JSI-backed day/week/month view, new architecture support on both iOS and Android.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**