### PR TITLE
Add @softwhere-uz/react-native-emoji-keyboard

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23654,5 +23654,14 @@
     "macos": true,
     "tvos": true,
     "windows": true
+  },
+  {
+    "githubUrl": "https://github.com/softwhere-uz/react-native-emoji-keyboard/tree/main/packages/react-native-emoji-keyboard",
+    "npmPkg": "@softwhere-uz/react-native-emoji-keyboard",
+    "examples": ["https://github.com/softwhere-uz/react-native-emoji-keyboard/tree/HEAD/example"],
+    "newArchitecture": true,
+    "ios": true,
+    "android": true,
+    "web": true
   }
 ]


### PR DESCRIPTION
Adds `@softwhere-uz/react-native-emoji-keyboard` — a universal (iOS · Android · Web), New-Architecture-first emoji keyboard & reaction picker for React Native and Expo.

- Bundled Emoji 17.0 data, FlashList v2 grid, deep token theming, first-class web parity.
- Per-emoji skin-tone memory, emoticon + multi-word search, reaction strip, bottom-sheet surface.
- Positioned as a drop-in successor to the unmaintained `rn-emoji-keyboard`.
- npm: https://www.npmjs.com/package/@softwhere-uz/react-native-emoji-keyboard

Entry added at the end of `react-native-libraries.json` per the contribution guide.