### PR TITLE
Update react-native-blasted-image: mark New Architecture support

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -19557,6 +19557,8 @@
     "githubUrl": "https://github.com/xerdnu/react-native-blasted-image",
     "ios": true,
     "android": true,
+    "newArchitecture": true,
+    "newArchitectureNote": "Supported via the New Architecture interop layer. Requires React Native 0.74+ when the New Architecture is enabled.",
     "fireos": true
   },
   {


### PR DESCRIPTION
The library works on the New Architecture out of the box via React Native's interop layer (legacy native module + legacy view manager and both auto-wrapped since RN 0.74). This is now documented in the README: https://github.com/xerdnu/react-native-blasted-image#new-architecture — added newArchitecture: true with a note about the RN 0.74+ requirement.

<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->

- [ ] Documented how you found or replicated the issue.
- [ ] Explained how you fixed the issue or built the feature.
- [ ] Described how to use or verify the change.

<!-- Thanks again for helping improve the project! 🙏 -->
