### PR TITLE
MarkdownRenderer: support GitHub theme variable image hash helpers

### DIFF
--- a/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
+++ b/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
@@ -36,6 +36,7 @@ type Props = {
 };
 
 export default function MarkdownRenderer({ data, repoUrl, linkableHeaders = true }: Props) {
+  const isDark = tw.prefixMatch('dark');
   const slugger = createSlugger();
   return (
     <Md
@@ -121,28 +122,41 @@ export default function MarkdownRenderer({ data, repoUrl, linkableHeaders = true
             </View>
           );
         },
-        img: ({ src, alt, width, height }: any) => (
-          <img
-            src={getReadmeAssetURL(src, repoUrl)}
-            onError={(error: any) => {
-              const fallbackUrl = getReadmeAssetURL(src, repoUrl, 'HEAD');
-              const target = error.currentTarget;
+        img: ({ src, alt, width, height }: any) => {
+          const baseURL = getReadmeAssetURL(src, repoUrl);
+          return (
+            <img
+              src={baseURL}
+              onError={(error: any) => {
+                const fallbackUrl = getReadmeAssetURL(src, repoUrl, 'HEAD');
+                const target = error.currentTarget;
 
-              if (target.src !== fallbackUrl) {
-                target.onerror = null;
-                target.src = fallbackUrl;
-              } else {
-                target.style.display = 'none';
-              }
-            }}
-            alt={alt ?? ''}
-            width={width}
-            height="auto"
-            style={{
-              maxHeight: height,
-            }}
-          />
-        ),
+                if (target.src !== fallbackUrl) {
+                  target.onerror = null;
+                  target.src = fallbackUrl;
+                } else {
+                  target.style.display = 'none';
+                }
+              }}
+              alt={alt ?? ''}
+              width={width}
+              height="auto"
+              style={{
+                ...(baseURL.endsWith('#gh-dark-mode-only')
+                  ? isDark
+                    ? tw`inline`
+                    : tw`hidden`
+                  : {}),
+                ...(baseURL.endsWith('#gh-light-mode-only')
+                  ? isDark
+                    ? tw`hidden`
+                    : tw`inline`
+                  : {}),
+                maxHeight: height,
+              }}
+            />
+          );
+        },
         source: ({ srcSet, ...rest }: any) => (
           <source srcSet={srcSet ? getReadmeAssetURL(srcSet, repoUrl) : undefined} {...rest} />
         ),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Add support for old way of specifying theme based images, nowadays most repositories use `source` tags (https://github.blog/changelog/2022-05-19-specify-theme-context-for-images-in-markdown-beta/), but there are still some cases of old way to control that via `#gh-dark/light-mode-only` hashes in image `src`. This PR adds support for that syntax.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

<img width="1833" height="1041" alt="Screenshot 2026-07-29 124019" src="https://github.com/user-attachments/assets/53052c62-fb1c-4277-9144-7e4a7b8b13d6" />
