### PR TITLE
MarkdownRenderer: improve typing of most of render components

### DIFF
--- a/components/Package/MarkdownContentBox/MarkdownHeading.tsx
+++ b/components/Package/MarkdownContentBox/MarkdownHeading.tsx
@@ -1,3 +1,4 @@
+import { type Element } from 'hast';
 import { type PropsWithChildren } from 'react';
 
 import { Button } from '~/components/Button';
@@ -6,32 +7,16 @@ import { childrenToText } from '~/util/strings';
 import tw from '~/util/tailwind';
 
 type Props = PropsWithChildren<{
-  node: MarkdownHeadingElement;
+  node: Element;
   slugger: (text: string) => string;
   linkableHeaders?: boolean;
 }>;
 
-export type MarkdownHeadingElement = Partial<Element> & {
-  tagName: MarkdownHeadingTagName;
-  position: {
-    start: MarkdownHeadingPosition;
-    end: MarkdownHeadingPosition;
-  };
-  properties: {
-    align?: 'left' | 'center' | 'right' | 'justify';
-  };
-};
-
 type MarkdownHeadingTagName = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-type MarkdownHeadingPosition = {
-  column: number;
-  line: number;
-  offset: number;
-};
 
 export default function MarkdownHeading({ children, slugger, node, linkableHeaders }: Props) {
-  const Heading = node.tagName;
-  const isCentered = node.properties.align === 'center';
+  const Heading = node.tagName as MarkdownHeadingTagName;
+  const isCentered = node.properties?.align === 'center';
 
   const slug = typeof children === 'string' ? slugger(children) : slugger(childrenToText(children));
 

--- a/components/Package/MarkdownContentBox/MarkdownInlineCode.tsx
+++ b/components/Package/MarkdownContentBox/MarkdownInlineCode.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { type Highlighter } from 'shiki';
 
 import { inlineHighlighterInstance } from '~/util/shiki';
 
 type Props = {
-  code: string;
+  code: ReactNode;
   theme: string;
 };
 

--- a/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
+++ b/components/Package/MarkdownContentBox/MarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import { Md } from '@m2d/react-markdown/client';
 import { capitalize } from 'es-toolkit/string';
-import { Children, isValidElement } from 'react';
+import { type Element } from 'hast';
+import { Children, type ComponentProps, isValidElement, type JSX } from 'react';
 import { View } from 'react-native';
 import { type Theme } from 'react-shiki';
 import rehypeRaw from 'rehype-raw';
@@ -35,195 +36,205 @@ type Props = {
   linkableHeaders?: boolean;
 };
 
+type ComponentType<T extends keyof JSX.IntrinsicElements> = JSX.IntrinsicElements[T] & {
+  node: Element;
+};
+
 export default function MarkdownRenderer({ data, repoUrl, linkableHeaders = true }: Props) {
   const isDark = tw.prefixMatch('dark');
   const slugger = createSlugger();
   return (
     <Md
       id="markdownContentContainer"
-      components={{
-        h1: ({ children, node }: any) => (
-          <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
-            {children}
-          </MarkdownHeading>
-        ),
-        h2: ({ children, node }: any) => (
-          <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
-            {children}
-          </MarkdownHeading>
-        ),
-        h3: ({ children, node }: any) => (
-          <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
-            {children}
-          </MarkdownHeading>
-        ),
-        h4: ({ children, node }: any) => (
-          <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
-            {children}
-          </MarkdownHeading>
-        ),
-        h5: ({ children, node }: any) => (
-          <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
-            {children}
-          </MarkdownHeading>
-        ),
-        h6: ({ children, node }: any) => (
-          <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
-            {children}
-          </MarkdownHeading>
-        ),
-        p: ({ children, node, ...props }: any) => {
-          const childrenCount = Children.count(children);
-          if (childrenCount === 1) {
-            const element = Children.toArray(children).at(0);
-            if (
-              isValidElement<{ href?: string }>(element) &&
-              isGitHubVideoAssetLink(element.props.href)
-            ) {
-              return children;
-            }
-          }
-
-          return <p {...props}>{children}</p>;
-        },
-        br: () => null,
-        hr: () => null,
-        a: (props: any) => {
-          if (props.href?.startsWith('#')) {
-            return <A {...props} target="_self" />;
-          } else if (props.href && !props.href.startsWith('//')) {
-            if (!props.href.startsWith('http')) {
-              return (
-                <A
-                  {...props}
-                  href={`${repoUrl}/blob/HEAD/${props.href.startsWith('/') ? props.href.slice(1) : props.href}`}
-                />
-              );
-            } else if (isGitHubVideoAssetLink(props.href)) {
-              return <MarkdownVideoPlayer src={props.href} />;
-            }
-            return <A {...props} />;
-          }
-          return <span>{props.children}</span>;
-        },
-        video: ({ src, width }: any) => {
-          if (src) {
-            return <MarkdownVideoPlayer src={src} style={{ width }} />;
-          }
-          return null;
-        },
-        table: ({ children, node }) => {
-          return (
-            <View
-              // @ts-expect-error dataSet is a valid RNW prop
-              dataSet={{ tableWrapper: true }}
-              style={node.properties.align === 'center' ? tw`mx-auto` : undefined}>
-              <table>{children}</table>
-            </View>
-          );
-        },
-        img: ({ src, alt, width, height }: any) => {
-          const baseURL = getReadmeAssetURL(src, repoUrl);
-          return (
-            <img
-              src={baseURL}
-              onError={(error: any) => {
-                const fallbackUrl = getReadmeAssetURL(src, repoUrl, 'HEAD');
-                const target = error.currentTarget;
-
-                if (target.src !== fallbackUrl) {
-                  target.onerror = null;
-                  target.src = fallbackUrl;
-                } else {
-                  target.style.display = 'none';
-                }
-              }}
-              alt={alt ?? ''}
-              width={width}
-              height="auto"
-              style={{
-                ...(baseURL.endsWith('#gh-dark-mode-only')
-                  ? isDark
-                    ? tw`inline`
-                    : tw`hidden`
-                  : {}),
-                ...(baseURL.endsWith('#gh-light-mode-only')
-                  ? isDark
-                    ? tw`hidden`
-                    : tw`inline`
-                  : {}),
-                maxHeight: height,
-              }}
-            />
-          );
-        },
-        source: ({ srcSet, ...rest }: any) => (
-          <source srcSet={srcSet ? getReadmeAssetURL(srcSet, repoUrl) : undefined} {...rest} />
-        ),
-        code: ({ children }: any) => (
-          <MarkdownInlineCode
-            code={children}
-            theme={tw.prefixMatch('dark') ? 'rnd-dark' : 'rnd-light'}
-          />
-        ),
-        pre: ({ children }: any) => {
-          const langClass = children?.props?.className;
-          return (
-            <MarkdownCodeBlock
-              code={children?.props?.children ?? childrenToText(children)}
-              theme={(tw.prefixMatch('dark') ? rndDark : rndLight) as Theme}
-              lang={langClass ? (langClass.split('-')[1] ?? 'sh').toLowerCase() : 'sh'}
-            />
-          );
-        },
-        blockquote: ({ children }: any) => {
-          const blockquoteType = extractAndStripBlockquoteType(children);
-          const Icon = blockquoteType.type ? getBlockquoteIcon(blockquoteType.type) : null;
-          return (
-            <blockquote
-              className={blockquoteType.type}
-              style={{
-                ...tw`text-secondary`,
-                ...(blockquoteType.type ? {} : tw`border-palette-gray4 dark:border-secondary`),
-              }}>
-              {blockquoteType.type && Icon && (
-                <strong className="blockquote-title" style={tw`flex items-center gap-1.5`}>
-                  <Icon style={tw`-ml-0.5 size-4`} />
-                  {capitalize(blockquoteType.type)}
-                </strong>
-              )}
-              {blockquoteType.children}
-            </blockquote>
-          );
-        },
-        details: ({ children }: any) => {
-          return (
-            <details
-              style={tw`mt-3 rounded-xl border border-palette-gray2 pb-3 pr-4 pt-1 dark:border-default`}>
+      components={
+        {
+          h1: ({ children, node }: ComponentType<'h1'>) => (
+            <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
               {children}
-            </details>
-          );
-        },
-        input: ({ type, checked, ...rest }: any) => {
-          if (type === 'checkbox') {
-            const isChecked = Boolean(checked);
+            </MarkdownHeading>
+          ),
+          h2: ({ children, node }: ComponentType<'h2'>) => (
+            <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
+              {children}
+            </MarkdownHeading>
+          ),
+          h3: ({ children, node }: ComponentType<'h3'>) => (
+            <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
+              {children}
+            </MarkdownHeading>
+          ),
+          h4: ({ children, node }: ComponentType<'h4'>) => (
+            <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
+              {children}
+            </MarkdownHeading>
+          ),
+          h5: ({ children, node }: ComponentType<'h5'>) => (
+            <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
+              {children}
+            </MarkdownHeading>
+          ),
+          h6: ({ children, node }: ComponentType<'h6'>) => (
+            <MarkdownHeading node={node} slugger={slugger} linkableHeaders={linkableHeaders}>
+              {children}
+            </MarkdownHeading>
+          ),
+          p: ({ children, ...props }: ComponentType<'p'>) => {
+            const childrenCount = Children.count(children);
+            if (childrenCount === 1) {
+              const element = Children.toArray(children).at(0);
+              if (
+                isValidElement<{ href?: string }>(element) &&
+                isGitHubVideoAssetLink(element.props.href)
+              ) {
+                return children;
+              }
+            }
+
+            return <p {...props}>{children}</p>;
+          },
+          br: () => null,
+          hr: () => null,
+          a: (props: any) => {
+            if (props.href && props.href.startsWith('#')) {
+              return <A {...props} target="_self" />;
+            } else if (props.href && !props.href.startsWith('//')) {
+              if (!props.href.startsWith('http')) {
+                return (
+                  <A
+                    {...props}
+                    href={`${repoUrl}/blob/HEAD/${props.href.startsWith('/') ? props.href.slice(1) : props.href}`}
+                  />
+                );
+              } else if (isGitHubVideoAssetLink(props.href)) {
+                return <MarkdownVideoPlayer src={props.href} />;
+              }
+              return <A {...props} />;
+            }
+            return <span>{props.children}</span>;
+          },
+          video: ({ src, width }: ComponentType<'video'>) => {
+            if (src) {
+              return <MarkdownVideoPlayer src={src} style={width ? { width } : undefined} />;
+            }
+            return null;
+          },
+          table: ({ children, node }: ComponentType<'table'>) => {
             return (
-              <div
-                className="checkbox"
-                style={tw`m-0 box-border size-4 items-center justify-center rounded border border-solid border-palette-gray3 bg-palette-gray2 dark:border-powder dark:bg-palette-gray6`}>
-                {isChecked && <CheckIcon style={tw`size-3 text-success`} />}
-              </div>
+              <View
+                // @ts-expect-error dataSet is a valid RNW prop
+                dataSet={{ tableWrapper: true }}
+                style={node.properties.align === 'center' ? tw`mx-auto` : undefined}>
+                <table>{children}</table>
+              </View>
             );
-          }
-          return <input type={type} {...rest} />;
-        },
-        sub: ({ children }: any) => {
-          return <sub className="block">{children}</sub>;
-        },
-        sup: ({ children }: any) => {
-          return <sup className="block">{children}</sup>;
-        },
-      }}
+          },
+          img: ({ src, alt, width, height }: ComponentType<'img'>) => {
+            if (!src || typeof src !== 'string') {
+              return null;
+            }
+
+            const baseURL = getReadmeAssetURL(src, repoUrl);
+            return (
+              <img
+                src={baseURL}
+                onError={error => {
+                  const fallbackUrl = getReadmeAssetURL(src, repoUrl, 'HEAD');
+                  const target = error.currentTarget;
+
+                  if (target.src !== fallbackUrl) {
+                    target.onerror = null;
+                    target.src = fallbackUrl;
+                  } else {
+                    target.style.display = 'none';
+                  }
+                }}
+                alt={alt ?? ''}
+                width={width}
+                height="auto"
+                style={{
+                  ...(baseURL.endsWith('#gh-dark-mode-only')
+                    ? isDark
+                      ? tw`inline`
+                      : tw`hidden`
+                    : {}),
+                  ...(baseURL.endsWith('#gh-light-mode-only')
+                    ? isDark
+                      ? tw`hidden`
+                      : tw`inline`
+                    : {}),
+                  maxHeight: height,
+                }}
+              />
+            );
+          },
+          source: ({ srcSet, ...rest }: ComponentType<'source'>) => (
+            <source srcSet={srcSet ? getReadmeAssetURL(srcSet, repoUrl) : undefined} {...rest} />
+          ),
+          code: ({ children }: ComponentType<'code'>) => (
+            <MarkdownInlineCode
+              code={children}
+              theme={tw.prefixMatch('dark') ? 'rnd-dark' : 'rnd-light'}
+            />
+          ),
+          pre: ({ children }: any) => {
+            const langClass = children?.props?.className;
+            return (
+              <MarkdownCodeBlock
+                code={children?.props?.children ?? childrenToText(children)}
+                theme={(tw.prefixMatch('dark') ? rndDark : rndLight) as Theme}
+                lang={langClass ? (langClass.split('-')[1] ?? 'sh').toLowerCase() : 'sh'}
+              />
+            );
+          },
+          blockquote: ({ children }: ComponentType<'blockquote'>) => {
+            const blockquoteType = extractAndStripBlockquoteType(children);
+            const Icon = blockquoteType.type ? getBlockquoteIcon(blockquoteType.type) : null;
+            return (
+              <blockquote
+                className={blockquoteType.type}
+                style={{
+                  ...tw`text-secondary`,
+                  ...(blockquoteType.type ? {} : tw`border-palette-gray4 dark:border-secondary`),
+                }}>
+                {blockquoteType.type && Icon && (
+                  <strong className="blockquote-title" style={tw`flex items-center gap-1.5`}>
+                    <Icon style={tw`-ml-0.5 size-4`} />
+                    {capitalize(blockquoteType.type)}
+                  </strong>
+                )}
+                {blockquoteType.children}
+              </blockquote>
+            );
+          },
+          details: ({ children }: ComponentType<'details'>) => {
+            return (
+              <details
+                style={tw`mt-3 rounded-xl border border-palette-gray2 pb-3 pr-4 pt-1 dark:border-default`}>
+                {children}
+              </details>
+            );
+          },
+          input: ({ type, checked, ...rest }: ComponentType<'input'>) => {
+            if (type === 'checkbox') {
+              const isChecked = Boolean(checked);
+              return (
+                <div
+                  className="checkbox"
+                  style={tw`m-0 box-border size-4 items-center justify-center rounded border border-solid border-palette-gray3 bg-palette-gray2 dark:border-powder dark:bg-palette-gray6`}>
+                  {isChecked && <CheckIcon style={tw`size-3 text-success`} />}
+                </div>
+              );
+            }
+            return <input type={type} {...rest} />;
+          },
+          sub: ({ children }: ComponentType<'sub'>) => {
+            return <sub className="block">{children}</sub>;
+          },
+          sup: ({ children }: ComponentType<'sup'>) => {
+            return <sup className="block">{children}</sup>;
+          },
+        } as Record<string, ComponentProps<any>>
+      }
       rehypePlugins={[rehypeRaw]}
       remarkPlugins={[remarkGfm, remarkEmoji]}>
       {data ?? undefined}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Unfortunately the build-in `@m2d/react-markdown` component typing is incorrect (all possible HTML tags types are merged in) and attempting to use exported types lead to the issues.

This PR add a simple local definition which should help catch some mistakes, still there are few use-cases which would need a refactor and component update across the codebase to work with the types, so for now I have left them as is.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.
