### PR TITLE
add @hzblj/zyplot library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23680,5 +23680,18 @@
     "newArchitecture": true,
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/hzblj/zyplot/tree/main/packages/zyplot",
+    "npmPkg": "@hzblj/zyplot",
+    "examples": ["https://github.com/hzblj/zyplot/tree/main/apps/example"],
+    "images": [
+      "https://raw.githubusercontent.com/hzblj/zyplot/main/apps/website/public/apps/kraken/light.png",
+      "https://raw.githubusercontent.com/hzblj/zyplot/main/apps/website/public/apps/revolut/light.png"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [`@hzblj/zyplot`](https://www.npmjs.com/package/@hzblj/zyplot) — a cross-platform chart library for React and Expo. One props contract renders through Swift Charts on iOS, Jetpack Compose on Android, and ECharts/uPlot on the web, so the same chart code runs on all three targets with no WebViews.

- Native views ship through an Expo module (`ExpoModulesCore`, `coreFeatures: ["swiftui", "compose"]`), so it needs a development build — not Expo Go.
- `githubUrl` points at `packages/zyplot` because the package lives in a monorepo; `npmPkg` is set since the repo name and the scoped package name differ.
- `web: true` — the example app runs on web through `react-native-web` (`expo start --web`), where the package resolves to its DOM renderer.
- `newArchitecture: true` — built on the Expo Modules API and developed against Expo SDK 55 / React Native 0.83.
- Docs: https://www.zyplot.janblazej.dev

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**