### PR TITLE
data: mark react-native-livechart as New Architecture compatible

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -22858,6 +22858,7 @@
     "images": [
       "https://raw.githubusercontent.com/brandtnewlabs/react-native-livechart/main/assets/images/hero.webp"
     ],
+    "newArchitecture": true,
     "ios": true,
     "android": true
   },

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -121,7 +121,7 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "newArchitecture": "new-arch-only",
+    "newArchitecture": true,
     "newArchitectureNote": "Works used with Expo modules dependencies. Alternative dependencies are not all compatible with the New Architecture."
   },
   {
@@ -22858,7 +22858,7 @@
     "images": [
       "https://raw.githubusercontent.com/brandtnewlabs/react-native-livechart/main/assets/images/hero.webp"
     ],
-    "newArchitecture": true,
+    "newArchitecture": "new-arch-only",
     "ios": true,
     "android": true
   },

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -121,7 +121,7 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "newArchitecture": true,
+    "newArchitecture": "new-arch-only",
     "newArchitectureNote": "Works used with Expo modules dependencies. Alternative dependencies are not all compatible with the New Architecture."
   },
   {


### PR DESCRIPTION
## Summary

- mark react-native-livechart as new-arch-only in react-native-libraries.json

## Context

react-native-livechart requires react-native-reanimated >=4.0.0. Reanimated 4 supports only the React Native New Architecture (Fabric), so the Directory entry should use the documented new-arch-only value rather than true.

The companion library change commits the monorepo package README so the Directory can discover it:
https://github.com/brandtnewlabs/react-native-livechart/pull/248

## Validation

- JSON parsed successfully with Node
- git diff --check passed