### PR TITLE
Update react-native-zoom-reanimated: Expo Go support, explicit npmPkg

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -10754,10 +10754,12 @@
   },
   {
     "githubUrl": "https://github.com/kesha-antonov/react-native-zoom-reanimated",
+    "npmPkg": "react-native-zoom-reanimated",
     "examples": ["https://github.com/kesha-antonov/react-native-zoom-reanimated/tree/main/example"],
     "ios": true,
     "android": true,
     "web": true,
+    "expoGo": true,
     "newArchitecture": true
   },
   {


### PR DESCRIPTION
Updating the entry for [`react-native-zoom-reanimated`](https://www.npmjs.com/package/react-native-zoom-reanimated) (I maintain it).

### Changes

- **`expoGo: true`** - the library ships no native code. Its `src/` imports only `react`, `react-native`, `react-native-gesture-handler` and `react-native-reanimated`, and both of those native dependencies are bundled in Expo Go, so it runs there without a dev client or prebuild.
- **`npmPkg`** - added explicitly. It matches the repository name so it was being inferred correctly, but stating it keeps the entry stable if that ever stops being true.

`ios`, `android`, `web` and `newArchitecture` are already correct and unchanged.