### PR TITLE
Add react-native-leap to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23812,9 +23812,7 @@
   },
   {
     "githubUrl": "https://github.com/hung-yueh/react-native-leap",
-    "examples": [
-      "https://github.com/hung-yueh/react-native-leap/tree/main/example"
-    ],
+    "examples": ["https://github.com/hung-yueh/react-native-leap/tree/main/example"],
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23809,5 +23809,14 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/hung-yueh/react-native-leap",
+    "examples": [
+      "https://github.com/hung-yueh/react-native-leap/tree/main/example"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
   }
 ]


### PR DESCRIPTION
Adds [`react-native-leap`](https://github.com/hung-yueh/react-native-leap) — on-device LFM2 / LFM2.5 inference for React Native & Expo, wrapping Liquid AI's LEAP SDK via Nitro Modules. Streaming chat, grammar-constrained JSON output, tool calling, vision, and speech-to-speech, all running locally.

- npm: https://www.npmjs.com/package/react-native-leap
- Example app: https://github.com/hung-yueh/react-native-leap/tree/main/example

`newArchitecture` is set to `"new-arch-only"` since the library is built on Nitro Modules and does not support the Old Architecture. iOS and Android are both supported and validated on a physical device / emulator; it is not compatible with Expo Go (an Expo config plugin is included for prebuild / dev clients).

Note: the package was first published to npm today, so `api.npmjs.org` may not return download data yet and the new-entry validation can fail on that check — as anticipated in `scripts/validate-new-entries.ts`. Happy to push an empty commit to re-trigger CI once the stats populate (or let me know if you would prefer I resubmit then).
