### PR TITLE
Add @gfean/react-native-bundle-drop

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23818,5 +23818,12 @@
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/GFean/react-native-bundle-drop",
+    "npmPkg": "@gfean/react-native-bundle-drop",
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

This PR adds `@gfean/react-native-bundle-drop` (https://github.com/GFean/react-native-bundle-drop) to React Native Directory.

Bundle Drop provides over-the-air update integration for React Native and Expo applications, with iOS and Android support.

Validated with:

- `bun run data:validate`
- `bun run data:test`
- `bun run ci:validate`
- `bun oxfmt react-native-libraries.json --check`

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
