### PR TITLE
Mark react-native-compressor as supporting the New Architecture

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -8215,7 +8215,8 @@
     ],
     "ios": true,
     "android": true,
-    "configPlugin": true
+    "configPlugin": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/garganurag893/react-native-phone-number-input",


### PR DESCRIPTION
## Why

`react-native-compressor` currently shows as **untested** on the New Architecture, but since [v2.0.0](https://github.com/numandev1/react-native-compressor/releases/tag/v2.0.0) it is built on [Nitro Modules](https://nitro.margelo.com/):

- peer dependency on `react-native-nitro-modules` (>=0.35.0)
- ships `nitrogen/`-generated bindings
- the library README states New Architecture support

Automatic detection misses it because it keys on `codegenConfig` in the package.json, which Nitro libraries don't use — so per the README guidance ("Set `newArchitecture` field only when automatic architecture detection fails for your package"), this adds the explicit flag.

Anecdata: we run v2.0.3 in production in an Expo SDK 54 app with the New Architecture enabled (the SDK 54 default) on both iOS and Android.

## How

One-line change: `"newArchitecture": true` on the `react-native-compressor` entry. `data:validate` (ajv schema validation) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)