### PR TITLE
Add insert-affiliate-react-native-sdk

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23855,5 +23855,11 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/Insert-Affiliate/InsertAffiliateReactNativeSDK",
+    "npmPkg": "insert-affiliate-react-native-sdk",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
Adds [insert-affiliate-react-native-sdk](https://www.npmjs.com/package/insert-affiliate-react-native-sdk), a React Native SDK for connecting with the Insert Affiliate platform to add app-based affiliate marketing.

- GitHub: https://github.com/Insert-Affiliate/InsertAffiliateReactNativeSDK
- npm: insert-affiliate-react-native-sdk
- Platforms: iOS, Android
- License: MIT