### PR TITLE
Add PoseTracker React Native pose estimation SDKs

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23887,5 +23887,29 @@
     "android": true,
     "ios": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/Movelytics/react-native-pose-estimation",
+    "npmPkg": "@pose-tracker/react-native-pose-estimation",
+    "examples": [
+      "https://github.com/Movelytics/react-native-pose-estimation-demo"
+    ],
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "newArchitecture": true,
+    "newArchitectureNote": "Default MoveNet backend runs in a WebView and works on the New Architecture. Optional Apple Vision backend is iOS native builds only (not Expo Go)."
+  },
+  {
+    "githubUrl": "https://github.com/Movelytics/react-native-pose-estimation-light",
+    "npmPkg": "@pose-tracker/react-native-pose-estimation-light",
+    "examples": [
+      "https://github.com/Movelytics/react-native-pose-estimation-light-demo"
+    ],
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "newArchitecture": true,
+    "newArchitectureNote": "Default MoveNet backend runs in a WebView and works on the New Architecture. Optional Apple Vision backend is iOS native builds only (not Expo Go)."
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23891,9 +23891,7 @@
   {
     "githubUrl": "https://github.com/Movelytics/react-native-pose-estimation",
     "npmPkg": "@pose-tracker/react-native-pose-estimation",
-    "examples": [
-      "https://github.com/Movelytics/react-native-pose-estimation-demo"
-    ],
+    "examples": ["https://github.com/Movelytics/react-native-pose-estimation-demo"],
     "ios": true,
     "android": true,
     "expoGo": true,
@@ -23903,9 +23901,7 @@
   {
     "githubUrl": "https://github.com/Movelytics/react-native-pose-estimation-light",
     "npmPkg": "@pose-tracker/react-native-pose-estimation-light",
-    "examples": [
-      "https://github.com/Movelytics/react-native-pose-estimation-light-demo"
-    ],
+    "examples": ["https://github.com/Movelytics/react-native-pose-estimation-light-demo"],
     "ios": true,
     "android": true,
     "expoGo": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23895,8 +23895,7 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "newArchitecture": true,
-    "newArchitectureNote": "Default MoveNet backend runs in a WebView and works on the New Architecture. Optional Apple Vision backend is iOS native builds only (not Expo Go)."
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/Movelytics/react-native-pose-estimation-light",
@@ -23905,7 +23904,6 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "newArchitecture": true,
-    "newArchitectureNote": "Default MoveNet backend runs in a WebView and works on the New Architecture. Optional Apple Vision backend is iOS native builds only (not Expo Go)."
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
## Summary

Adds two PoseTracker packages to the directory:

- [`@pose-tracker/react-native-pose-estimation`](https://www.npmjs.com/package/@pose-tracker/react-native-pose-estimation) — offline / bundled MoveNet Lightning
- [`@pose-tracker/react-native-pose-estimation-light`](https://www.npmjs.com/package/@pose-tracker/react-native-pose-estimation-light) — light / CDN model

Both run on **iOS + Android**, including **Expo Go** (WebView + `react-native-webview`). Default backend is WebView so New Architecture works; optional Apple Vision is iOS native builds only.

Examples are the Expo Go demo apps:
- https://github.com/Movelytics/react-native-pose-estimation-demo
- https://github.com/Movelytics/react-native-pose-estimation-light-demo

Docs: https://docs.posetracker.com

`web` is omitted on purpose: these packages are not `react-native-web` libraries (there is a separate browser SDK).

## Test plan

- [ ] Directory CI / validate-new-entries passes
- [ ] Packages resolve on npm
- [ ] GitHub URLs and demo example URLs load

Made with [Cursor](https://cursor.com)