### PR TITLE
Add Expo Snack example for PoseTracker

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23891,7 +23891,10 @@
   {
     "githubUrl": "https://github.com/Movelytics/react-native-pose-estimation",
     "npmPkg": "@pose-tracker/react-native-pose-estimation",
-    "examples": ["https://github.com/Movelytics/react-native-pose-estimation-demo"],
+    "examples": [
+      "https://github.com/Movelytics/react-native-pose-estimation-demo",
+      "https://snack.expo.dev/@fsepret/posetracker-sdk-demo-app"
+    ],
     "ios": true,
     "android": true,
     "expoGo": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23903,7 +23903,10 @@
   {
     "githubUrl": "https://github.com/Movelytics/react-native-pose-estimation-light",
     "npmPkg": "@pose-tracker/react-native-pose-estimation-light",
-    "examples": ["https://github.com/Movelytics/react-native-pose-estimation-light-demo"],
+    "examples": [
+      "https://github.com/Movelytics/react-native-pose-estimation-light-demo",
+      "https://snack.expo.dev/@fsepret/posetracker-sdk-light-demo-app"
+    ],
     "ios": true,
     "android": true,
     "expoGo": true,


### PR DESCRIPTION
## Summary
- Adds the working Expo Snack for `@pose-tracker/react-native-pose-estimation`: https://snack.expo.dev/@fsepret/posetracker-sdk-demo-app
- GitHub demo URL is unchanged

Follow-up to #2742 (GitHub import into Snack fails on demo assets; this Snack is a saved Expo Go example).

## Test plan
- [ ] Snack URL opens
- [ ] Directory CI / oxfmt passes


Made with [Cursor](https://cursor.com)