### PR TITLE
Add rn-typed-assets and rn-newarch-ready

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23905,5 +23905,18 @@
     "android": true,
     "expoGo": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/AndrewDongminYoo/rn-typed-assets",
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/AndrewDongminYoo/rn-newarch-ready",
+    "ios": true,
+    "android": true,
+    "dev": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds two React Native development tools, both MIT and published to npm:

- **[rn-typed-assets](https://github.com/AndrewDongminYoo/rn-typed-assets)** — generates a type-safe asset registry (images / SVG / Lottie) from the project's asset folders, reports unreferenced files, and rewrites stale `require()` paths.
- **[rn-newarch-ready](https://github.com/AndrewDongminYoo/rn-newarch-ready)** — read-only New Architecture readiness audit: classifies each dependency, flags archived libraries, and finds app-local native modules still on legacy APIs.

Both are CLIs run through `npx` at development time and ship no native code into the app, so each entry is marked `"dev": true`. Entries were appended at the end of the file, following the template field order.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
