### PR TITLE
Add three New Architecture native modules

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23918,5 +23918,28 @@
     "ios": true,
     "android": true,
     "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/AndrewDongminYoo/react-native-receipt-scanner",
+    "examples": ["https://github.com/AndrewDongminYoo/react-native-receipt-scanner/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/AndrewDongminYoo/react-native-step-counter",
+    "npmPkg": "react-native-step-counter-newarch",
+    "examples": ["https://github.com/AndrewDongminYoo/react-native-step-counter/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/AndrewDongminYoo/react-native-naver-login",
+    "npmPkg": "react-native-naver-login-turbo",
+    "examples": ["https://github.com/AndrewDongminYoo/react-native-naver-login/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23921,7 +23921,9 @@
   },
   {
     "githubUrl": "https://github.com/AndrewDongminYoo/react-native-receipt-scanner",
-    "examples": ["https://github.com/AndrewDongminYoo/react-native-receipt-scanner/tree/main/example"],
+    "examples": [
+      "https://github.com/AndrewDongminYoo/react-native-receipt-scanner/tree/main/example"
+    ],
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"


### PR DESCRIPTION
# 📝 Why & how

Adds three React Native native modules I maintain. All are published to npm, MIT,
ship `codegenConfig`, and have an example app in the repository.

| Package | What it wraps |
| --- | --- |
| `react-native-receipt-scanner` | ML Kit document scanner, for capturing a receipt as a cropped, deskewed image |
| `react-native-step-counter-newarch` | Android `StepCounter`/`StepDetector` sensors and iOS `CMPedometer` |
| `react-native-naver-login-turbo` | Naver OAuth 2.0 login |

Each is marked `"newArchitecture": "new-arch-only"`: they are TurboModule/Fabric
implementations with no legacy Bridge path, so a host app needs `newArchEnabled=true`.
All three contain custom native code and ship no Expo config plugin, so `expoGo` is
not set.

Two entries carry `npmPkg` because the published package name differs from the
repository name.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
