### PR TITLE
Add @rs-native-kit/version-check

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23949,5 +23949,20 @@
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/rajssinde/rs-native-kit-version-check",
+    "npmPkg": "@rs-native-kit/version-check",
+    "examples": [
+      "https://github.com/rajssinde/rs-native-kit-version-check/tree/main/example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/rajssinde/rs-native-kit-version-check/main/.github/assets/force-update-screen.png",
+      "https://raw.githubusercontent.com/rajssinde/rs-native-kit-version-check/main/.github/assets/theme-showcase.png"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "newArchitecture": "new-arch-only"
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23953,9 +23953,7 @@
   {
     "githubUrl": "https://github.com/rajssinde/rs-native-kit-version-check",
     "npmPkg": "@rs-native-kit/version-check",
-    "examples": [
-      "https://github.com/rajssinde/rs-native-kit-version-check/tree/main/example"
-    ],
+    "examples": ["https://github.com/rajssinde/rs-native-kit-version-check/tree/main/example"],
     "images": [
       "https://raw.githubusercontent.com/rajssinde/rs-native-kit-version-check/main/.github/assets/force-update-screen.png",
       "https://raw.githubusercontent.com/rajssinde/rs-native-kit-version-check/main/.github/assets/theme-showcase.png"


### PR DESCRIPTION
## Summary
Adds `@rs-native-kit/version-check` to the directory.

Force/soft-update prompts for React Native — compares the running app's version against the App Store, Google Play, or a custom API and returns a typed `ActionPlan` (`FORCE_UPDATE` / `SOFT_UPDATE` / `OPTIONAL_REMINDER` / `NO_ACTION`). Native surface is a Nitro Module (New Architecture only, no legacy bridge). iOS, Android, and Web (via `react-native-web`).

- npm: https://www.npmjs.com/package/@rs-native-kit/version-check
- repo: https://github.com/rajssinde/rs-native-kit-version-check

## Checklist
- [x] Entry added at the end of `react-native-libraries.json`, following the template field order/indentation
- [x] Validated against `react-native-libraries.schema.json` via `ajv-cli` — passes
- [x] Both image URLs resolve (HTTP 200) on `main`
- [x] `examples` links to the in-repo `example/` app