### PR TITLE
Mark react-native-razorpay as supporting the New Architecture

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12863,8 +12863,7 @@
       "https://github.com/razorpay/react-native-razorpay/tree/master/sampleApps/OldArchSample"
     ],
     "ios": true,
-    "android": true,
-    "newArchitecture": false
+    "android": true
   },
   {
     "githubUrl": "https://github.com/customerglu/CG-SDK-React-Native",


### PR DESCRIPTION
# 📝 Why & how

`react-native-razorpay` is currently reported as **Unsupported on New Architecture**, but it has supported it since `3.0.0` (published 2026-04-21).

**How I found it**

Running `expo-doctor` on an Expo SDK 57 / RN 0.86 app flags the package, and the check API agrees:

```
POST https://reactnative.directory/api/libraries/check
{"packages":["react-native-razorpay"]}
→ {"react-native-razorpay":{"newArchitecture":"unsupported"}}
```

But the same record's auto-detected fields disagree with its own status:

```
GET https://reactnative.directory/api/libraries?search=razorpay
→ github.newArchitecture: true,  moduleType: "turbo"
```

**Why the two disagree**

`3.0.0` genuinely added New Architecture support upstream:

- `codegenConfig` in `package.json` (`RNRazorpayCheckoutSpec`, `type: "modules"`)
- TurboModule specs — `src/NativeRazorpayCheckout.ts`, `src/NativeRazorpayEventEmitter.ts`
- split Android source sets, `android/src/newarch` and `android/src/oldarch`, selected by `newArchEnabled`
- `RazorpayModule` extending the generated `NativeRazorpayCheckoutSpec`
- a podspec that now uses `install_modules_dependencies` and the `RCT_NEW_ARCH_ENABLED` path

So `fetch-github-data.ts` resolves `Boolean(packageJson.codegenConfig)` to `true` — which is where `github.newArchitecture: true` comes from.

The entry in `react-native-libraries.json` still carried a manual `"newArchitecture": false` from before that release, and `getNewArchSupportStatus` prefers the manual field over the detected one:

```ts
if (typeof newArchitecture !== 'undefined') {
  flag = newArchitecture;          // ← stale false wins here
} else if (github.newArchitecture === true) {
  flag = true;
}
```

**The change**

Removed the override rather than flipping it to `true`, following the README:

> Set `newArchitecture` field only when automatic architecture detection fails for your package, despite it supports the New Architecture.

Detection does not fail here, so leaving the field off lets the entry track the package by itself. Happy to set it to `true` instead if you'd rather keep it explicit.

**How to verify**

`getNewArchSupportStatus` now falls through to `github.newArchitecture === true` and returns `Supported`. The entry's own `examples` already link `NewArchSample` and `Expo54Sample`, which were added alongside the upstream release.

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**
- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.
- [x] Described how to use or verify the change.
