### PR TITLE
Add expo-gradle-properties

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23961,5 +23961,11 @@
     "android": true,
     "web": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/dangerdeveloper/expo-gradle-properties",
+    "android": true,
+    "configPlugin": true,
+    "dev": true
   }
 ]


### PR DESCRIPTION
Adds [`expo-gradle-properties`](https://github.com/dangerdeveloper/expo-gradle-properties) — an Expo config plugin that writes arbitrary keys into the generated `android/gradle.properties`.

```json
{
  "githubUrl": "https://github.com/dangerdeveloper/expo-gradle-properties",
  "android": true,
  "configPlugin": true,
  "dev": true
}
```

### What it does

In a prebuild app, `android/gradle.properties` is regenerated on every `expo prebuild`, so a config plugin is the only durable way to set values in it. `expo-build-properties` covers exactly one of those keys (`buildArchs` → `reactNativeArchitectures`) and has no generic option, so properties like `org.gradle.jvmargs`, `kotlin.daemon.jvmargs` and `org.gradle.caching` are not expressible today. This plugin fills that gap, validates keys and values against the `.properties` format, and warns when `$GRADLE_USER_HOME/gradle.properties` silently overrides the project file.

### Notes on the flags

- `android` — Android only; there is no iOS counterpart to this file.
- `configPlugin` — the package *is* the config plugin.
- `dev` — it is build-time only and contributes nothing to the running app.
- Platform flags left `false` are omitted per the template, and `npmPkg` is omitted since the npm name matches the repository name.
- `newArchitecture` is omitted — the plugin doesn't touch app runtime code, so I've left it to automatic detection.

Published on npm as [`expo-gradle-properties`](https://www.npmjs.com/package/expo-gradle-properties), MIT, with tests and CI.