### PR TITLE
Update Nitro Image package metadata

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -19029,9 +19029,11 @@
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-nitro-image/tree/main/packages/react-native-nitro-image",
+    "examples": ["https://github.com/mrousavy/react-native-nitro-image/tree/main/example"],
     "ios": true,
     "android": true,
-    "fireos": true
+    "fireos": true,
+    "newArchitecture": "new-arch-only"
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-nitro-image/tree/main/packages/react-native-nitro-web-image",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -19037,8 +19037,10 @@
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-nitro-image/tree/main/packages/react-native-nitro-web-image",
+    "examples": ["https://github.com/mrousavy/react-native-nitro-image/tree/main/example"],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture": "new-arch-only"
   },
   {
     "githubUrl": "https://github.com/BlixtWallet/react-native-nitro-ark/tree/master/react-native-nitro-ark",


### PR DESCRIPTION
# 📝 Why & how

Updates both Nitro Image packages with their shared example application and correct New Architecture status:

- `react-native-nitro-image` uses a Nitro View, which requires the New Architecture.
- `react-native-nitro-web-image` depends on `react-native-nitro-image`, so the package stack is also New Architecture only.

This replaces the currently inferred untested status with the documented compatibility status for both packages.

Validated with:

- `bun data:test`
- `bun data:validate`
- `bun ci:validate`
- `bun lint`

# ✅ Checklist

- [x] Updated libraries in **`react-native-libraries.json`**