### PR TITLE
Mark react-native-nitro-modules as a runtime library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14484,7 +14484,6 @@
     "tvos": true,
     "macos": true,
     "visionos": true,
-    "dev": true,
     "newArchitecture": true,
     "fireos": true
   },


### PR DESCRIPTION
# 📝 Why & how

Removes the development-tool tag from `react-native-nitro-modules`.

The package is the runtime core for Nitro Modules and its documentation instructs applications to install it as a normal dependency. `nitrogen` remains separately listed and marked as a development tool because it is the optional code generator for library authors.

The existing `newArchitecture: true` value remains correct because Nitro HybridObjects support both the old and New Architectures.

Validated with:

- `bun data:test`
- `bun data:validate`
- `bun ci:validate`
- `bun lint`

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**