### PR TITLE
Update VisionCamera v5 metadata

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -7105,9 +7105,7 @@
     "ios": true,
     "android": true,
     "fireos": true,
-    "newArchitecture": true,
-    "newArchitectureNote": "Currently supported through the compatibility layer for legacy view components.",
-    "configPlugin": true
+    "newArchitecture": "new-arch-only"
   },
   {
     "githubUrl": "https://github.com/dabakovich/react-native-controlled-mentions",
@@ -21883,33 +21881,48 @@
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-vision-camera/tree/main/packages/react-native-vision-camera-barcode-scanner",
+    "examples": [
+      "https://github.com/mrousavy/react-native-vision-camera/tree/main/apps/simple-camera"
+    ],
     "ios": true,
     "android": true,
-    "newArchitecture": true
+    "newArchitecture": "new-arch-only"
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-vision-camera/tree/main/packages/react-native-vision-camera-location",
+    "examples": [
+      "https://github.com/mrousavy/react-native-vision-camera/tree/main/apps/simple-camera"
+    ],
     "ios": true,
     "android": true,
-    "newArchitecture": true
+    "newArchitecture": "new-arch-only"
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-vision-camera/tree/main/packages/react-native-vision-camera-resizer",
+    "examples": [
+      "https://github.com/mrousavy/react-native-vision-camera/tree/main/apps/simple-camera"
+    ],
     "ios": true,
     "android": true,
-    "newArchitecture": true
+    "newArchitecture": "new-arch-only"
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-vision-camera/tree/main/packages/react-native-vision-camera-skia",
+    "examples": [
+      "https://github.com/mrousavy/react-native-vision-camera/tree/main/apps/simple-camera"
+    ],
     "ios": true,
     "android": true,
-    "newArchitecture": true
+    "newArchitecture": "new-arch-only"
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-vision-camera/tree/main/packages/react-native-vision-camera-worklets",
+    "examples": [
+      "https://github.com/mrousavy/react-native-vision-camera/tree/main/apps/simple-camera"
+    ],
     "ios": true,
     "android": true,
-    "newArchitecture": true
+    "newArchitecture": "new-arch-only"
   },
   {
     "githubUrl": "https://github.com/shubh73/expo-ruler",


### PR DESCRIPTION
# 📝 Why & how

Updates the VisionCamera domain for the v5 Nitro rewrite:

- Marks `react-native-vision-camera` and all five v5 companion packages as New Architecture only.
- Removes the obsolete legacy-view compatibility note from the core package.
- Removes `configPlugin` because VisionCamera v5 no longer ships an Expo config plugin.
- Adds the shared `apps/simple-camera` example to each companion package. The app installs and exercises the barcode scanner, location, resizer, Skia, and worklets packages.

VisionCamera v5 uses Nitro Views, which require the New Architecture. Each companion package depends on the v5 core package.

Validated with:

- `bun data:test`
- `bun data:validate`
- `bun ci:validate`
- `bun lint`

# ✅ Checklist

- [x] Updated libraries in **`react-native-libraries.json`**