### PR TITLE
Add react-native-object-capture

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24006,5 +24006,10 @@
     "android": true,
     "expoGo": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/tristanheilman/react-native-object-capture",
+    "ios": true,
+    "newArchitecture": "new-arch-only"
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [`react-native-object-capture`](https://github.com/tristanheilman/react-native-object-capture) to React Native Directory.

The metadata follows the package owner's documented support contract:

- iOS only — Android intentionally ships a buildable stub because Android has no Object Capture equivalent
- New Architecture only — the package requires Fabric/TurboModules and has no legacy architecture path
- npm package name matches the repository name, so no redundant `npmPkg` override is included
- optional fields are omitted per the Directory entry rules

The package is published on npm as `react-native-object-capture@0.2.6`.

Validation:

- `bun data:test`
- `bun data:validate`
- `bun ci:validate`
- `bun lint`

Closes tristanheilman/react-native-object-capture#31.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
