### PR TITLE
Add @pulse-rn/sdk

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24017,7 +24017,6 @@
     "npmPkg": "@pulse-rn/sdk",
     "examples": ["https://github.com/maahibhama/PulseRN/tree/main/apps/example-react-native"],
     "ios": true,
-    "android": true,
-    "dev": true
+    "android": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24011,5 +24011,13 @@
     "githubUrl": "https://github.com/tristanheilman/react-native-object-capture",
     "ios": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/maahibhama/PulseRN/tree/main/packages/sdk",
+    "npmPkg": "@pulse-rn/sdk",
+    "examples": ["https://github.com/maahibhama/PulseRN/tree/main/apps/example-react-native"],
+    "ios": true,
+    "android": true,
+    "dev": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Add the published `@pulse-rn/sdk` package from the PulseRN monorepo. PulseRN is a development-only React Native debugger SDK with documented Android and iOS support and a maintained example app.

The `githubUrl` points directly to `packages/sdk` because the monorepo root package is private. The entry deliberately does not claim Expo Go, web, out-of-tree platforms, a config plugin, or a manual New Architecture override.

Tracks maahibhama/PulseRN#37. Passing these checks does not claim upstream acceptance before this PR is merged.

Verification:

- `bun data:validate`
- `bun data:test`
- `CI_CHECKS_TOKEN=... bun ci:validate`
- `bun oxfmt react-native-libraries.json --check`
- `bun lint`

All checks pass. The initial root-repository entry correctly failed `ci:validate` because the root `package.json` is private; targeting `packages/sdk` resolved the npm/GitHub metadata check.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
- [x] Documented how eligibility and package metadata were verified.
- [x] Described how to verify the change with the official data validators.