### PR TITLE
Add react-native-password-intelligence

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24070,5 +24070,15 @@
     "examples": ["https://github.com/sfourdrinier/unified-ble-manager/tree/main/example-expo"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/mobilteknolojileri/react-native-password-intelligence",
+    "examples": [
+      "https://github.com/mobilteknolojileri/react-native-password-intelligence/tree/main/example"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [`react-native-password-intelligence`](https://github.com/mobilteknolojileri/react-native-password-intelligence) to the directory.

It's a password strength estimator built on zxcvbn-ts, with an extra dictionary layer for Turkish: first names, surnames, nicknames, football clubs and their slang, province names, plate-code patterns like `34istanbul`, local brands and keyboard walks. These are everywhere in passwords here, but the stock zxcvbn dictionaries have never seen them, so something like `fenerbahce1907` scores far higher than it should. Exports `PasswordMeter` for the UI, `usePasswordRisk` if you want to render your own, and `analyzePassword` if you only need the score.

- npm: https://www.npmjs.com/package/react-native-password-intelligence
- Example app: https://github.com/mobilteknolojileri/react-native-password-intelligence/tree/main/example

JS/TS only with no native code, so iOS, Android, web and Expo Go all work. I left out `npmPkg` since the repo and package names match, and `newArchitecture` since the README says to leave that to auto-detection unless it fails.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
- [x] Validated schema, formatting and duplicates locally
