### PR TITLE
Add rn-story

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24080,5 +24080,13 @@
     "android": true,
     "web": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/AbdullahAnsarii/rn-story",
+    "examples": ["https://github.com/AbdullahAnsarii/rn-story/tree/master/example"],
+    "images": ["https://raw.githubusercontent.com/AbdullahAnsarii/rn-story/master/docs/demo.jpg"],
+    "ios": true,
+    "android": true,
+    "web": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [rn-story](https://github.com/AbdullahAnsarii/rn-story) ([npm](https://www.npmjs.com/package/rn-story)) — a lightweight, TypeScript-first component for Instagram/WhatsApp/Snapchat-style stories. Image and video stories with animated progress bars, tap-to-navigate and long-press-to-pause gestures, per-story "See More" links, and a custom header slot. Works with Expo (expo-av peer dependency); v2.0.1 also runs on react-native-web.

Entry appended at the end of `react-native-libraries.json` per the contribution guide, with a screenshot and a link to the bundled example app.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**