### PR TITLE
Add expo-tts-file

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24080,5 +24080,15 @@
     "android": true,
     "web": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/ksblazh/expo-tts-file",
+    "npmPkg": "expo-tts-file",
+    "examples": [
+      "https://github.com/ksblazh/expo-tts-file/tree/main/example"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds [`expo-tts-file`](https://github.com/ksblazh/expo-tts-file) — on-device text-to-speech synthesized **to an audio file**, offline, for React Native / Expo.

The directory has plenty of TTS-adjacent entries, but they cover live speech (`expo-speech`, `react-native-tts`) or speech *recognition*. This one writes the synthesized audio to disk, which is what you need for offline playback, background audio, or building a clip from text ahead of time.

- Swift + Kotlin via the Expo Modules API; iOS 16.4+, Android API 24+
- Output is platform-native PCM — CAF on iOS, WAV on Android
- TypeScript types, an example app, and a CHANGELOG
- Published to npm with SLSA provenance

`newArchitecture` is set explicitly because the automatic detection keys off `packageJson.codegenConfig`, which an Expo Modules API package does not have. The module is developed and tested against Expo SDK 57 / React Native 0.86, with iOS and Android builds running in CI on every PR.

Requires a development build rather than Expo Go, so `expoGo` is left out. `tvos` is left out as well — the platform is declared by the podspec but untested, and the guidelines ask for a working example before claiming an out-of-tree platform.