### PR TITLE
Add a demo image for expo-tts-file

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24092,6 +24092,7 @@
   {
     "githubUrl": "https://github.com/ksblazh/expo-tts-file",
     "examples": ["https://github.com/ksblazh/expo-tts-file/tree/main/example"],
+    "images": ["https://raw.githubusercontent.com/ksblazh/expo-tts-file/main/docs/demo.gif"],
     "ios": true,
     "android": true,
     "newArchitecture": true


### PR DESCRIPTION
Adds an `images` entry for [`expo-tts-file`](https://github.com/ksblazh/expo-tts-file), merged into the directory a couple of days ago in #2764.

The recording shows what the package does on a device: it synthesizes text to an audio file, then plays that file back with each word highlighted in time with the speech. The highlighting is driven by word timings returned alongside the file rather than by live progress events, which is why it still lines up on replay and on seek.

Hosted from the package's own repository, so nothing new is added to this repo.