### PR TITLE
Add @ant-design/react-native and @ant-design/icons-react-native

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24095,5 +24095,18 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/ant-design/ant-design-mobile-rn",
+    "npmPkg": "@ant-design/react-native",
+    "examples": ["https://github.com/ant-design/ant-design-mobile-rn/tree/master/example"],
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/ant-design/ant-design-icons/tree/master/packages/icons-react-native",
+    "npmPkg": "@ant-design/icons-react-native",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [@ant-design/react-native](https://www.npmjs.com/package/@ant-design/react-native) — Ant Design's React Native UI library ([ant-design/ant-design-mobile-rn](https://github.com/ant-design/ant-design-mobile-rn)) — and its companion icon package [@ant-design/icons-react-native](https://www.npmjs.com/package/@ant-design/icons-react-native) (from the [ant-design-icons monorepo](https://github.com/ant-design/ant-design-icons/tree/master/packages/icons-react-native)).

Neither package has directory metadata today, so `expo doctor` reports "No metadata available" for both — as requested in ant-design/ant-design-mobile-rn#1452.

Entries are appended at the end of `react-native-libraries.json` per the contribution guide, with `npmPkg` set since both package names differ from their repo names.

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**